### PR TITLE
feat(scrollOffset): return scrollOffset from useVirtual

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -14,6 +14,7 @@ const {
   totalSize,
   scrollToIndex,
   scrollToOffset,
+  scrollOffset,
 } = useVirtual({
   size,
   parentRef,
@@ -119,3 +120,7 @@ const {
     - `center` places the offset in the center of the visible scroll area
     - `end` places the offset at the bottom/right of the visible scroll area
     - `auto` brings the offset into the visible scroll area either at the start or end, depending on which is closer. If the offset is already in view, it is placed at the `top/left` of the visible scroll area.
+- `scrollOffset: number`
+  - The scroll offset of the virtualizer at the time of rendering.
+  - Can be used to implement scroll position dependent functionality, such as pagination UI.
+  - `useVirtual` causes the host component to re-render on every scroll event. This offset is returned so you can implement scroll offset dependent functionality without adding second onScroll event which would result in double rendering and tearing.

--- a/src/index.js
+++ b/src/index.js
@@ -281,6 +281,7 @@ export function useVirtual({
     scrollToOffset,
     scrollToIndex,
     measure,
+    scrollOffset,
   }
 }
 

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -24,6 +24,7 @@ function List({
 
   return (
     <>
+      <div data-testid="scrollOffset">{rowVirtualizer.scrollOffset}</div>
       <div
         ref={parentRef}
         style={{
@@ -134,5 +135,20 @@ describe('useVirtual list', () => {
     expect(screen.queryByText('Row 0')).toBeInTheDocument()
     expect(screen.queryByText('Row 1')).toBeInTheDocument()
     expect(screen.queryByText('Row 2')).not.toBeInTheDocument()
+  })
+  it('should update scrollOffset', async () => {
+    const onRef = virtualRow => el => {
+      if (el) {
+        jest.spyOn(el, 'offsetHeight', 'get').mockImplementation(() => 25)
+      }
+      virtualRow.measureRef(el)
+    }
+    render(<List {...props} onRef={onRef} />)
+
+    expect(screen.queryByTestId('scrollOffset')).toHaveTextContent(/^0$/)
+
+    fireEvent.scroll(parentRef.current, { target: { scrollTop: 100 } })
+
+    expect(screen.queryByTestId('scrollOffset')).toHaveTextContent(/^100$/)
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,12 +52,15 @@ export interface Options<T> {
   rangeExtractor?: (range: Range) => number[]
 }
 
-declare function useVirtual<T>(options: Options<T>): {
+declare function useVirtual<T>(
+  options: Options<T>
+): {
   virtualItems: VirtualItem[]
   totalSize: number
   scrollToOffset: (index: number, options?: ScrollToOffsetOptions) => void
   scrollToIndex: (index: number, options?: ScrollToIndexOptions) => void
   measure: () => void
+  scrollOffset: number
 }
 
 export { defaultRangeExtractor, useVirtual }


### PR DESCRIPTION
## What is the change?

useVirtual now returns its scrollOffset state.

Docs, tests, and types for the behaviour have been included.

## Motivation

There are a variety of reasons you may want to implement behaviour that is dependent on the current scroll offset of the virtualizer. e.g. Pagination UI like "displaying rows 1-5" or a "Scroll to top" that only shows when `scrollOffset > tooCloseToStart`.

Right now to implement this kind of behaviour the host component needs to add its own `onScroll` handler and update a state. However `useVirtual` already has a `scrollOffset` state updated once on every scroll event resulting in a re-render. As a result if the host component adds its own `onScroll` that changes state, then the host component will re-render **twice** on every single scroll event. Even though `useVirtual` already has all the information that is needed to implement that kind of behaviour and the 2nd re-render is entirely unnecessary and would halve the component's performance. Additionally the UI could experience tearing as the render where useVirtual's new list of items to display and the render where the pagination UI is updated are separate renders.

Here's a demo showing the double render behaviour which would be avoided if useVirtual didn't hide the scrollOffset.
https://codesandbox.io/s/usevirtual-with-an-extra-scroll-event-3q6jqz?file=/src/main.jsx
