### PR TITLE
ci: fix branch name

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -3,7 +3,7 @@ name: react-virtual tests
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
   publish-module:
     name: 'Publish Module to NPM'
     needs: test
-    if: github.ref == 'refs/heads/master' #publish only when merged in master, not on PR
+    if: github.ref == 'refs/heads/main' #publish only when merged in main, not on PR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/TanStack/react-virtual/commit/061075751c3fad630710c0f7794e587a6cf9dda0 was not published because CI did not run for it, after the default branch was renamed to `main`.