### PR TITLE
Fix `onScrollElement` docs

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -66,7 +66,7 @@ const {
 - `paddingEnd: Integer`
   - Defaults to `0`
   - The amount of padding in pixels to add to the end of the virtual list
-  - `onScrollElement: React.useRef(DOMElement)`
+- `onScrollElement: React.useRef(DOMElement)`
   - Optional
   - Allows using a different element to bind the `onScroll` event to
 - `scrollOffsetFn: Function(event?: Event) => number`


### PR DESCRIPTION
Fixes the list nesting in the docs for `onScrollElement`