### PR TITLE
fix: remove unnecessary imports from `virtual-core/src/index.ts` #298

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1,6 +1,4 @@
 import observeRect from '@reach/observe-rect'
-import { check } from 'prettier'
-import React from 'react'
 import { memo } from './utils'
 
 export * from './utils'


### PR DESCRIPTION
Closes #298


Other changes:

it removes [a react import](https://github.com/TanStack/virtual/compare/beta...FaberVitale:fix-%23298?expand=1#diff-85d1b85f3d4e501779ca41e51cd38cf7f61a2b7ffddaf958cd7e79c2787c36f1L3)
