### PR TITLE
fix: Rename broken url links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Headless UI for virtualizing scrollable elements in TS/JS and React
 <br />
 <br />
 
-Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [React Query](https://github.com/@tanstack/react-query), [TanStack Table](https://github.com/@tanstack/table), [React Charts](https://github.com/@tanstack/react-charts)
+Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [React Query](https://github.com/TanStack/react-query), [TanStack Table](https://github.com/TanStack/table), [React Charts](https://github.com/TanStack/react-charts)
 
 ## Visit [tanstack.com/virtual](https://tanstack.com/virtual) for docs, guides, API and more!
 


### PR DESCRIPTION
Rename based url from `https://github.com/@tanstack` to `https://github.com/TanStack`

<img width="1495" alt="Capture d’écran 2022-06-05 à 08 28 40" src="https://user-images.githubusercontent.com/2315749/172038392-6e38edb4-9626-4ff9-add1-e690f6ee112a.png">

