### PR TITLE
chore: lock yarn version with yarnPath

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs


### PR DESCRIPTION
Add yarn and ref it via yarnPath

> The yarnPath setting is currently the preferred way to install Yarn within a project, as it ensures that your whole team will use the exact same Yarn version, without having to individually keep it up-to-date.

from docs https://yarnpkg.com/configuration/yarnrc/#yarnPath