### PR TITLE
fix: Add `solid-virtual` package to tsconfig paths

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "baseUrl": ".",
     "paths": {
       "@tanstack/virtual-core": ["packages/virtual-core"],
-      "@tanstack/react-virtual": ["packages/react-virtual"]
+      "@tanstack/react-virtual": ["packages/react-virtual"],
+      "@tanstack/solid-virtual": ["packages/solid-virtual"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "files": [],
   "references": [
     { "path": "packages/virtual-core" },
-    { "path": "packages/react-virtual" }
+    { "path": "packages/react-virtual" },
+    { "path": "packages/solid-virtual" }
     // { "path": "examples/react/basic/tsconfig.dev.json" },
   ]
   // "exclude": ["node_modules"]


### PR DESCRIPTION
I believe the build build workflow for solid-virtual failed yesterday because it didn't include types in the dist folder. This was because solid-virtual's path wasn't added in the root tsconfig. This change fixes that. Let me know if you want me to make other changes 😄 