### PR TITLE
Add React v18 strict mode support

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -284,6 +284,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
   private cleanup = () => {
     this.unsubs.filter(Boolean).forEach((d) => d!())
     this.unsubs = []
+    this.scrollElement = null
   }
 
   _didMount = () => {


### PR DESCRIPTION
Hi everyone, thanks for making this awesome library!

The goal of this PR is to add strict mode support for React v18

React v18 in strict mode runs `useEffect` twice in dev mode, as documented in [ReactJS blog](https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors)

For this reason, the `cleanup` function is called after the initial mount of the component, which does call/clear `this.unsubs`, but the scrolling element `this.scrollElement` remains set.

When `useEffect` runs the second time, the `_willUpdate` if check
 ```js
if (this.scrollElement !== scrollElement) {...
```
evals as `false`, and prevents new subs from being set, resulting in broken virtualisation behaviour, as noted in issue #322 

This PR aims to solve the issue by enhancing the cleanup function so the aforementioned `if` block evals to `true` on subsequent re-renders so the new subs are properly set.

Here is the relevant `react-virtual` code for context: https://github.com/TanStack/virtual/blob/beta/packages/react-virtual/src/index.tsx#L39-L45