### PR TITLE
feat: Allow explicitly overriding `smoothScroll` in scrollToIndex()/scrollToOffset()

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -227,7 +227,8 @@ Returns the virtual items for the current state of the virtualizer.
 scrollToOffset: (
   toOffset: number,
   options?: {
-    align?: 'start' | 'center' | 'end' | 'auto'
+    align?: 'start' | 'center' | 'end' | 'auto',
+    smoothScroll?: boolean
   }
 ) => void
 ```
@@ -239,8 +240,9 @@ Scrolls the virtualizer to the pixel offset provided. You can optionally pass an
 ```tsx
 scrollToIndex: (
   index: number,
-  options: {
-    align?: 'start' | 'center' | 'end' | 'auto'
+  options?: {
+    align?: 'start' | 'center' | 'end' | 'auto',
+    smoothScroll?: boolean
   }
 ) => void
 ```

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -8,8 +8,8 @@ export * from './utils'
 type ScrollAlignment = 'start' | 'center' | 'end' | 'auto'
 
 export interface ScrollToOptions {
-  align: ScrollAlignment
-  smoothScroll: boolean
+  align?: ScrollAlignment
+  smoothScroll?: boolean
 }
 
 type ScrollToOffsetOptions = ScrollToOptions
@@ -489,7 +489,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
   scrollToOffset = (
     toOffset: number,
-    { align, smoothScroll }: ScrollToOffsetOptions = { align: 'start', smoothScroll: this.options.enableSmoothScroll },
+    { align = 'start', smoothScroll = this.options.enableSmoothScroll }: ScrollToOffsetOptions = {},
   ) => {
     const attempt = () => {
       const offset = this.scrollOffset
@@ -522,7 +522,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
   scrollToIndex = (
     index: number,
-    { align, smoothScroll, ...rest }: ScrollToIndexOptions = { align: 'auto', smoothScroll: this.options.enableSmoothScroll },
+    { align = 'auto', smoothScroll = this.options.enableSmoothScroll, ...rest }: ScrollToIndexOptions = {},
   ) => {
     const measurements = this.getMeasurements()
     const offset = this.scrollOffset

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -9,6 +9,7 @@ type ScrollAlignment = 'start' | 'center' | 'end' | 'auto'
 
 export interface ScrollToOptions {
   align: ScrollAlignment
+  smoothScroll: boolean
 }
 
 type ScrollToOffsetOptions = ScrollToOptions
@@ -488,7 +489,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
   scrollToOffset = (
     toOffset: number,
-    { align }: ScrollToOffsetOptions = { align: 'start' },
+    { align, smoothScroll }: ScrollToOffsetOptions = { align: 'start', smoothScroll: this.options.enableSmoothScroll },
   ) => {
     const attempt = () => {
       const offset = this.scrollOffset
@@ -505,11 +506,11 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
       }
 
       if (align === 'start') {
-        this._scrollToOffset(toOffset, true)
+        this._scrollToOffset(toOffset, smoothScroll)
       } else if (align === 'end') {
-        this._scrollToOffset(toOffset - size, true)
+        this._scrollToOffset(toOffset - size, smoothScroll)
       } else if (align === 'center') {
-        this._scrollToOffset(toOffset - size / 2, true)
+        this._scrollToOffset(toOffset - size / 2, smoothScroll)
       }
     }
 
@@ -521,7 +522,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
   scrollToIndex = (
     index: number,
-    { align, ...rest }: ScrollToIndexOptions = { align: 'auto' },
+    { align, smoothScroll, ...rest }: ScrollToIndexOptions = { align: 'auto', smoothScroll: this.options.enableSmoothScroll },
   ) => {
     const measurements = this.getMeasurements()
     const offset = this.scrollOffset
@@ -552,7 +553,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
         ? measurement.end + this.options.scrollPaddingEnd
         : measurement.start - this.options.scrollPaddingStart
 
-    this.scrollToOffset(toOffset, { align, ...rest })
+    this.scrollToOffset(toOffset, { align, smoothScroll, ...rest })
   }
 
   getTotalSize = () =>
@@ -565,7 +566,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
     this.destinationOffset = offset
     this.options.scrollToFn(
       offset,
-      this.options.enableSmoothScroll && canSmooth,
+      canSmooth,
       this,
     )
 


### PR DESCRIPTION
From the commit message:

> Allow to explicitly override `smoothScroll` when calling scrollToOffset()/scrollToIndex(). Fall back to the global option `enableSmoothScrolling` when the parameter is not explicitly set.

The default behavior is unchanged. That is, when `enableSmoothScroll` is set to true, both scrollToIndex() and scrollToOffset() use smooth scrolling, and if false they don't.

This makes it possible to set the smooth scrolling behavior at the call-site, which is more flexible. Example usage:
```js
scrollToIndex(10, { smoothScroll: false }) // Explicitly set smooth scroll
scrollToIndex(10, { align: 'center', smoothScroll: false }) // Also explicitly set alignment
scrollToIndex(10) // Falls back to `options.enableSmoothScroll`
```

---

Note: I failed to link the package locally so this PR is not tested yet. I tried running `npm run build` and then `npm link` the react-virtual package so that I can test it locally with my project, but I always ran into errors. I didn't find any contributors guide, so any guidance here would be appreciated :)