### PR TITLE
Only re-render on range changes

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -328,14 +328,14 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
       this.unsubs.push(
         this.options.observeElementRect(this, (rect) => {
           this.scrollRect = rect
-          this.notify()
+          this.calculateRange()
         }),
       )
 
       this.unsubs.push(
         this.options.observeElementOffset(this, (offset) => {
           this.scrollOffset = offset
-          this.notify()
+          this.calculateRange()
         }),
       )
     }
@@ -394,6 +394,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
       })
       if (range.startIndex !== this.range.startIndex || range.endIndex !== this.range.endIndex) {
         this.range = range
+        this.notify()
       }
       return this.range
     },
@@ -406,7 +407,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
   private getIndexes = memo(
     () => [
       this.options.rangeExtractor,
-      this.calculateRange(),
+      this.range,
       this.options.overscan,
       this.options.count,
     ],

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -269,6 +269,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
     number,
     (measurableItem: TItemElement | null) => void
   > = {}
+  private range: { startIndex: number, endIndex: number } = { startIndex: 0, endIndex: 0 }
 
   constructor(opts: VirtualizerOptions<TScrollElement, TItemElement>) {
     this.setOptions(opts)
@@ -386,11 +387,15 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
   private calculateRange = memo(
     () => [this.getMeasurements(), this.getSize(), this.scrollOffset],
     (measurements, outerSize, scrollOffset) => {
-      return calculateRange({
+      const range = calculateRange({
         measurements,
         outerSize,
         scrollOffset,
       })
+      if (range.startIndex !== this.range.startIndex || range.endIndex !== this.range.endIndex) {
+        this.range = range
+      }
+      return this.range
     },
     {
       key: process.env.NODE_ENV === 'development' && 'calculateRange',


### PR DESCRIPTION
Only notify clients when the range of items changes, thus avoiding many unnecessary updates. Also improves smooth scrolling performance, which equally triggered massive amounts of re-renders.

The current behavior can still be obtained in user-land by simply attaching a scroll listener to the `scrollElement` and calling `measure()` in the event handler

**Note**: So far only tested with the react-virtual adapter
Fixes #352 

---

_Reduces re-renders from this: (watch the re-renders)_

https://user-images.githubusercontent.com/15364860/181907731-3ab351f9-d706-4066-ac7e-1337af0ed7ff.mov

_To this:_

https://user-images.githubusercontent.com/15364860/181907738-534605ce-6e2f-45d6-9197-4c4961731d26.mov
