### PR TITLE
Fix `initialOffset` not working

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -330,6 +330,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
       this.cleanup()
 
       this.scrollElement = scrollElement
+      this._scrollToOffset(this.scrollOffset, false)
 
       this.unsubs.push(
         this.options.observeElementRect(this, (rect) => {


### PR DESCRIPTION
Explicitly scroll to the correct offset.

The range was initially calculated correctly, but the scroll position of `scrollElement` was 0 (which causes the range to be re-calculated to match the visible area). The same applies for SSR usage: the scroll position cannot be transmitted from the server, so it needs to be restored explicitly on the client.

**Note**: Needs to be tested with a SSR setup
Fixes https://github.com/TanStack/virtual/issues/346