### PR TITLE
fix: Fix `initialRect` not working

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -278,6 +278,8 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
     this.setOptions(opts)
     this.scrollRect = this.options.initialRect
     this.scrollOffset = this.options.initialOffset
+
+    this.calculateRange()
   }
 
   setOptions = (opts: VirtualizerOptions<TScrollElement, TItemElement>) => {


### PR DESCRIPTION
Make sure the first render has the correct range.

Before (no `initialRect`, renders initially always `overscan` + 1):
<img width="306" alt="Screen Shot 2022-08-03 at 11 26 02" src="https://user-images.githubusercontent.com/15364860/182574355-c1b41c57-5205-4c6a-8471-c21611696431.png">

After (with `initialRect`, docs example with height set to 200px):
<img width="265" alt="Screen Shot 2022-08-03 at 11 26 14" src="https://user-images.githubusercontent.com/15364860/182574511-c3e9c483-4abe-4b42-9b72-bc492a7a0706.png">

