### PR TITLE
fix: Re-calculate range when options change

### DIFF
--- a/packages/react-virtual/__tests__/index.test.tsx
+++ b/packages/react-virtual/__tests__/index.test.tsx
@@ -125,12 +125,13 @@ test.only('should render given dynamic size after scroll', () => {
     target: { scrollTop: 400 },
   })
 
-  expect(screen.queryByText('Row 3')).not.toBeInTheDocument()
-  expect(screen.queryByText('Row 4')).toBeInTheDocument()
-  expect(screen.queryByText('Row 9')).toBeInTheDocument()
-  expect(screen.queryByText('Row 10')).not.toBeInTheDocument()
+  expect(screen.queryByText('Row 2')).not.toBeInTheDocument()
+  expect(screen.queryByText('Row 3')).toBeInTheDocument()
+  expect(screen.queryByText('Row 6')).toBeInTheDocument()
+  expect(screen.queryByText('Row 7')).not.toBeInTheDocument()
 
-  expect(renderer).toHaveBeenCalledTimes(2)
+  // The component is rendered multiple times, because the range changes after each render when the `estimateSize()` estimate is replaced by the items' actual size
+  expect(renderer).toHaveBeenCalledTimes(5)
 })
 
 test('should use rangeExtractor', () => {

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -257,7 +257,7 @@ export interface VirtualizerOptions<
 
 export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
   private unsubs: (void | (() => void))[] = []
-  options!: Required<VirtualizerOptions<TScrollElement, TItemElement>>
+  options!: Required<Omit<VirtualizerOptions<TScrollElement, TItemElement>, 'initialOffset' | 'initialRect'>>
   scrollElement: TScrollElement | null = null
   private measurementsCache: Item[] = []
   private itemMeasurementsCache: Record<Key, number> = {}
@@ -276,11 +276,9 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
   }
 
   constructor(opts: VirtualizerOptions<TScrollElement, TItemElement>) {
+    this.scrollRect = opts.initialRect || { width: 0, height: 0 }
+    this.scrollOffset = opts.initialOffset || 0
     this.setOptions(opts)
-    this.scrollRect = this.options.initialRect
-    this.scrollOffset = this.options.initialOffset
-
-    this.calculateRange()
   }
 
   setOptions = (opts: VirtualizerOptions<TScrollElement, TItemElement>) => {
@@ -290,7 +288,6 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
     this.options = {
       debug: false,
-      initialOffset: 0,
       overscan: 1,
       paddingStart: 0,
       paddingEnd: 0,
@@ -302,9 +299,10 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
       enableSmoothScroll: true,
       onChange: () => {},
       measureElement,
-      initialRect: { width: 0, height: 0 },
       ...opts,
     }
+
+    this.calculateRange()
   }
 
   private notify = () => {


### PR DESCRIPTION
Since https://github.com/TanStack/virtual/pull/353, we don't re-calculate the virtualized range in the render function anymore, but instead only when on scroll or size changes. This introduced a regression, where dynamically updating the `count` or other options did not cause an update to the range, and thus no re-render.

Fix this by explicitly calling `this.calculateRange()` in `this.setOptions()`, effectively makes it reactive to any options changes.

*Toggling the `count` option between 0 and 10000, items update accordingly*:

https://user-images.githubusercontent.com/15364860/184197568-237593ae-e611-49d9-9812-73507da18e8f.mov


Fixes https://github.com/TanStack/virtual/issues/363