### PR TITLE
Add the missing dependency "lodash" to package.json

### DIFF
--- a/examples/react/sticky/package.json
+++ b/examples/react/sticky/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-virtual": "3.0.0-beta.18",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+    "lodash": "^4.17.21",
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^4.0.0",


### PR DESCRIPTION
We need it at here: https://github.com/TanStack/virtual/blob/beta/examples/react/sticky/src/main.tsx#L5