### PR TITLE
fix #376: flushing the item ref function and forcing a remeasurement

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -600,6 +600,7 @@ export class Virtualizer<TScrollElement = unknown, TItemElement = unknown> {
 
   measure = () => {
     this.itemMeasurementsCache = {}
+    this.measureElementCache = {}
     this.notify()
   }
 }


### PR DESCRIPTION
This solution works. However, this the approach taken to flush the cache is not perfect as the table moves around when running `measure`. The lack of idempotence shows that it could be improved, presumably by maintaining the measurements for non visible items and only recalculating the ones visible.