### PR TITLE
Fix stale range when updating options

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -38,7 +38,6 @@ function useVirtualizerBase<
   )
 
   instance.setOptions(resolvedOptions)
-  instance.calculateRange()
 
   React.useEffect(() => {
     return instance._didMount()

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -38,6 +38,7 @@ function useVirtualizerBase<
   )
 
   instance.setOptions(resolvedOptions)
+  instance.calculateRange()
 
   React.useEffect(() => {
     return instance._didMount()

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -514,7 +514,7 @@ export class Virtualizer<
   private getIndexes = memo(
     () => [
       this.options.rangeExtractor,
-      this.range,
+      this.calculateRange(),
       this.options.overscan,
       this.options.count,
     ],


### PR DESCRIPTION
As seen in #485 when the list re-renders, it resolves the new indexes based on a stale range. The goal of this PR is to make sure indexes are always resolved based on an updated range.

Not sure if it defeats the optimizations made in #353. From what I understand most methods are memoized but `.notify()` may end up being called too often?

Fixes #485 