### PR TITLE
Allow callbacks for scroll padding values

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -99,18 +99,18 @@ The padding to apply to the end of the virtualizer in pixels.
 ### `scrollPaddingStart`
 
 ```tsx
-scrollPaddingStart?: number
+scrollPaddingStart?: number | (() => number)
 ```
 
-The padding to apply to the start of the virtualizer in pixels when scrolling to an element.
+The padding to apply to the start of the virtualizer in pixels when scrolling to an element. Alternatively can be a callback to compute the padding just-in-time.
 
 ### `scrollPaddingEnd`
 
 ```tsx
-scrollPaddingEnd?: number
+scrollPaddingEnd?: number | (() => number)
 ```
 
-The padding to apply to the end of the virtualizer in pixels when scrolling to an element.
+The padding to apply to the end of the virtualizer in pixels when scrolling to an element. Alternatively can be a callback to compute the padding just-in-time.
 
 ### `initialOffset`
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -268,8 +268,8 @@ export interface VirtualizerOptions<
   horizontal?: boolean
   paddingStart?: number
   paddingEnd?: number
-  scrollPaddingStart?: number
-  scrollPaddingEnd?: number
+  scrollPaddingStart?: number | (() => number)
+  scrollPaddingEnd?: number | (() => number)
   initialOffset?: number
   getItemKey?: (index: number) => Key
   rangeExtractor?: (range: Range) => number[]
@@ -724,12 +724,12 @@ export class Virtualizer<
     if (align === 'auto') {
       if (
         measurement.end >=
-        this.scrollOffset + this.getSize() - this.options.scrollPaddingEnd
+        this.scrollOffset + this.getSize() - valueOrCallback(this.options.scrollPaddingEnd)
       ) {
         align = 'end'
       } else if (
         measurement.start <=
-        this.scrollOffset + this.options.scrollPaddingStart
+        this.scrollOffset + valueOrCallback(this.options.scrollPaddingStart)
       ) {
         align = 'start'
       } else {
@@ -740,8 +740,8 @@ export class Virtualizer<
     const getOffsetForIndexAndAlignment = (measurement: VirtualItem) => {
       const toOffset =
         align === 'end'
-          ? measurement.end + this.options.scrollPaddingEnd
-          : measurement.start - this.options.scrollPaddingStart
+          ? measurement.end + valueOrCallback(this.options.scrollPaddingEnd)
+          : measurement.start - valueOrCallback(this.options.scrollPaddingStart)
 
       return this.getOffsetForAlignment(toOffset, align)
     }
@@ -866,4 +866,13 @@ function calculateRange({
   }
 
   return { startIndex, endIndex }
+}
+
+type NotAFunction<ValueType> = ValueType extends Function ? never : ValueType
+function valueOrCallback<ValueType>(value: NotAFunction<ValueType> | (() => NotAFunction<ValueType>)): ValueType {
+  if (typeof value === 'function') {
+    return value()
+  } else {
+    return value
+  }
 }


### PR DESCRIPTION
This makes the setting a bit more ergonomic since it allows computing the padding dynamically instead of hard-coding it. 

For example, in React:
```tsx
function Component() {
  const ref = useRef<HTMLDivElement>();
  const virtualizer = useVirtualizer({
    // ...
    scrollPaddingEnd: () => ref.current?.getBoundingClientRect().y ?? 0
  });

  return (
    <div
      style={{
        height: virtualizer.getTotalSize(),
        width: "100%",
        position: "relative",
      }}
      ref={ref}
    >
      {/* ... */}
    </div>
  );
    