### PR TITLE
Bugfix:  dynamically changing data structure is not reactive

### DIFF
--- a/packages/vue-virtual/package.json
+++ b/packages/vue-virtual/package.json
@@ -49,6 +49,6 @@
     "@tanstack/virtual-core": "3.0.0-beta.45"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^2.7.0"
   }
 }

--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -56,6 +56,7 @@ function useVirtualizerBase<
       })
 
       virtualizer._willUpdate()
+      triggerRef(state)
     },
     {
       immediate: true,


### PR DESCRIPTION
1. I have found a bug where after instantiating Virtualizer with empty array (count = 0), and later populating that array, will not show list at all. Since we are using `shallowRef`, we need to `triggerRef` in order for list to be updated, not only in onChange handler (which will be triggering if scroll available) but in watcher for options as well. 

2. It would be really great if we could use adapter for Vue2.7 as well, considering same primitives used for this adapter seem to work in v2.7 also. I implemented this manually in Vue2.7 with `virtual-core` and current beta code from vue-virtual, and it works just nicely (with the aforementioned fix). 

I also updated Vue version in peerDependencies to allow installation in Vue2.7, dunno if that is enough for this to work for 2.7, opinions needed here.

Repro vue2.7: https://codesandbox.io/s/virtual-test-vue2-lq2d35?file=/src/virtual.js
Repro vue3: https://codesandbox.io/s/virtual-test-vue3-3x1gnv?file=/src/virtual.js