### PR TITLE
(vue-virtual): removed information that says vue adapter is not devel…

### DIFF
--- a/docs/adapters/vue-virtual.md
+++ b/docs/adapters/vue-virtual.md
@@ -2,8 +2,6 @@
 title: Vue Virtual (Coming Soon)
 ---
 
-> ⚠️ This module has not yet been developed. It requires an adapter similiar to `@tanstack/react-virtual` to work. We estimate the amount of code to do this is very minimal, but does require familiarity with the Vue framework. If you would like to contribute this adapter, please open a PR!
-
 The `@tanstack/vue-virtual` adapter is a wrapper around the core virtual logic.
 
 ## `useVirtualizer`

--- a/packages/vue-virtual/package.json
+++ b/packages/vue-virtual/package.json
@@ -2,7 +2,7 @@
   "name": "@tanstack/vue-virtual",
   "author": "Tanner Linsley",
   "version": "3.0.0-beta.47",
-  "description": "Headless UI for virtualizing scrollable elements in Solid",
+  "description": "Headless UI for virtualizing scrollable elements in Vue",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/virtual#readme",
   "repository": {


### PR DESCRIPTION
…oped, as it is confusing for people coming to see if there is any progress here. Now it is aligned with svelte, solid and react, as all of them have adapters in beta also. Also updated package.json so it says Vue not Solid in description.