### PR TITLE
fix: replace typeof window checks with typeof document

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -15,7 +15,7 @@ export * from '@tanstack/virtual-core'
 //
 
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+  typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
 function useVirtualizerBase<
   TScrollElement extends Element | Window,
@@ -77,7 +77,7 @@ export function useWindowVirtualizer<TItemElement extends Element>(
   >,
 ): Virtualizer<Window, TItemElement> {
   return useVirtualizerBase<Window, TItemElement>({
-    getScrollElement: () => (typeof window !== 'undefined' ? window : null!),
+    getScrollElement: () => (typeof document !== 'undefined' ? window : null!),
     observeElementRect: observeWindowRect,
     observeElementOffset: observeWindowOffset,
     scrollToFn: windowScroll,

--- a/packages/solid-virtual/src/index.tsx
+++ b/packages/solid-virtual/src/index.tsx
@@ -118,7 +118,7 @@ export function createWindowVirtualizer<TItemElement extends Element>(
     mergeProps(
       {
         getScrollElement: () =>
-          typeof window !== 'undefined' ? window : null!,
+          typeof document !== 'undefined' ? window : null!,
         observeElementRect: observeWindowRect,
         observeElementOffset: observeWindowOffset,
         scrollToFn: windowScroll,

--- a/packages/svelte-virtual/src/index.ts
+++ b/packages/svelte-virtual/src/index.ts
@@ -88,7 +88,7 @@ export function createWindowVirtualizer<TItemElement extends Element>(
   >,
 ): Readable<SvelteVirtualizer<Window, TItemElement>> {
   return createVirtualizerBase<Window, TItemElement>({
-    getScrollElement: () => (typeof window !== 'undefined' ? window : null!),
+    getScrollElement: () => (typeof document !== 'undefined' ? window : null!),
     observeElementRect: observeWindowRect,
     observeElementOffset: observeWindowOffset,
     scrollToFn: windowScroll,

--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -103,7 +103,8 @@ export function useWindowVirtualizer<TItemElement extends Element>(
   return useVirtualizerBase<Window, TItemElement>(
     computed(() => ({
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      getScrollElement: () => (typeof Window !== 'undefined' ? window : null!),
+      getScrollElement: () =>
+        typeof document !== 'undefined' ? window : null!,
       observeElementRect: observeWindowRect,
       observeElementOffset: observeWindowOffset,
       scrollToFn: windowScroll,


### PR DESCRIPTION
currently the `@tanstack/react-virtual` package throws `useLayoutEffect does nothing on the server` warnings during ssr when using a deno runtime. this is because deno has a global window object available for browser compatibility (though is being considered for removal https://github.com/denoland/deno/issues/13367). also see [here](https://remix.run/docs/en/v1/pages/gotchas#typeof-window-checks) for further reading.

this pr replaces all `typeof window` checks across all packages with `typeof document` instead which works in all environments.

prior art: https://github.com/framer/motion/pull/1522