### PR TITLE
Add unsupported type guard for Safari `borderBoxSize`

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -76,7 +76,7 @@ export const observeElementRect = <T extends Element>(
 
   const observer = new ResizeObserver((entries) => {
     const entry = entries[0]
-    if (entry) {
+    if (entry?.borderBoxSize?.[0]) {
       const box = entry.borderBoxSize[0]
       if (box) {
         handler({ width: box.inlineSize, height: box.blockSize })
@@ -167,7 +167,7 @@ export const measureElement = <TItemElement extends Element>(
   entry: ResizeObserverEntry | undefined,
   instance: Virtualizer<any, TItemElement>,
 ) => {
-  if (entry) {
+  if (entry?.borderBoxSize?.[0]) {
     const box = entry.borderBoxSize[0]
     if (box) {
       const size = Math.round(

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -76,7 +76,7 @@ export const observeElementRect = <T extends Element>(
 
   const observer = new ResizeObserver((entries) => {
     const entry = entries[0]
-    if (entry?.borderBoxSize?.[0]) {
+    if (entry?.borderBoxSize) {
       const box = entry.borderBoxSize[0]
       if (box) {
         handler({ width: box.inlineSize, height: box.blockSize })
@@ -167,7 +167,7 @@ export const measureElement = <TItemElement extends Element>(
   entry: ResizeObserverEntry | undefined,
   instance: Virtualizer<any, TItemElement>,
 ) => {
-  if (entry?.borderBoxSize?.[0]) {
+  if (entry?.borderBoxSize) {
     const box = entry.borderBoxSize[0]
     if (box) {
       const size = Math.round(


### PR DESCRIPTION
## Descriptions
Currently, the borderBoxSize property in ResizeObserverEntry is not supported on Safari. This can cause errors and unexpected behavior in applications that rely on this property. This pull request proposes the addition of an unsupported type guard for Safari's borderBoxSize to prevent errors and improve the user experience.

## Changes
Added optional chaining to the borderBoxSize type guard in ResizeObserverEntry for browsers that do not support this property.
