### PR TITLE
feat: add support for masonry

### DIFF
--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -55,3 +55,11 @@ size: number
 ```
 
 The size of the item. This is usually mapped to a css property like `width/height`. Before an item is measured with the `VirtualItem.measureElement` method, this will be the estimated size returned from your `estimateSize` virtualizer option. After an item is measured (if you choose to measure it at all), this value will be the number returned by your `measureElement` virtualizer option (which by default is configured to measure elements with `getBoundingClientRect()`).
+
+### `column`
+
+```tsx
+column: number
+```
+
+The column index of the item. In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).

--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -56,10 +56,10 @@ size: number
 
 The size of the item. This is usually mapped to a css property like `width/height`. Before an item is measured with the `VirtualItem.measureElement` method, this will be the estimated size returned from your `estimateSize` virtualizer option. After an item is measured (if you choose to measure it at all), this value will be the number returned by your `measureElement` virtualizer option (which by default is configured to measure elements with `getBoundingClientRect()`).
 
-### `column`
+### `lane`
 
 ```tsx
-column: number
+lane: number
 ```
 
-The column index of the item. In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).
+The lane index of the item. In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -283,3 +283,11 @@ Measures the element using your configured `measureElement` virtualizer option. 
 ```
 
 By default the `measureElement` virtualizer option is configured to measure elements with `getBoundingClientRect()`.
+
+### `columns`
+
+```tsx
+columns: number
+```
+
+The number of columns the list is divided into.

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -284,10 +284,10 @@ Measures the element using your configured `measureElement` virtualizer option. 
 
 By default the `measureElement` virtualizer option is configured to measure elements with `getBoundingClientRect()`.
 
-### `columns`
+### `lanes`
 
 ```tsx
-columns: number
+lanes: number
 ```
 
-The number of columns the list is divided into.
+The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists).

--- a/examples/react/variable/src/main.tsx
+++ b/examples/react/variable/src/main.tsx
@@ -235,7 +235,7 @@ function MasonryVerticalVirtualizerVariable({ rows }) {
     getScrollElement: () => parentRef.current,
     estimateSize: (i) => rows[i],
     overscan: 5,
-    columns: 4,
+    lanes: 4,
   })
 
   return (
@@ -263,7 +263,7 @@ function MasonryVerticalVirtualizerVariable({ rows }) {
               style={{
                 position: 'absolute',
                 top: 0,
-                left: `${virtualRow.column * 25}%`,
+                left: `${virtualRow.lane * 25}%`,
                 width: '25%',
                 height: `${rows[virtualRow.index]}px`,
                 transform: `translateY(${virtualRow.start}px)`,
@@ -287,7 +287,7 @@ function MasonryHorizontalVirtualizerVariable({ rows }) {
     getScrollElement: () => parentRef.current,
     estimateSize: (i) => columns[i],
     overscan: 5,
-    columns: 4,
+    lanes: 4,
   })
 
   return (
@@ -316,7 +316,7 @@ function MasonryHorizontalVirtualizerVariable({ rows }) {
               }
               style={{
                 position: 'absolute',
-                top: `${virtualColumn.column * 25}%`,
+                top: `${virtualColumn.lane * 25}%`,
                 left: 0,
                 height: '25%',
                 width: `${columns[virtualColumn.index]}px`,

--- a/examples/react/variable/src/main.tsx
+++ b/examples/react/variable/src/main.tsx
@@ -35,6 +35,10 @@ function App() {
       <GridVirtualizerVariable rows={rows} columns={columns} />
       <br />
       <br />
+      <h3>Masonry</h3>
+      <MasonryVirtualizerVariable rows={rows} />
+      <br />
+      <br />
       {process.env.NODE_ENV === 'development' ? (
         <p>
           <strong>Notice:</strong> You are currently running React in
@@ -212,6 +216,59 @@ function GridVirtualizerVariable({ rows, columns }) {
                 </div>
               ))}
             </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function MasonryVirtualizerVariable({ rows }) {
+  const parentRef = React.useRef()
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (i) => rows[i],
+    overscan: 5,
+    columns: 4,
+  })
+
+  return (
+    <>
+      <div
+        ref={parentRef}
+        className="List"
+        style={{
+          height: `200px`,
+          width: `400px`,
+          overflow: 'auto',
+        }}
+      >
+        <div
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().map((virtualRow) => (
+            <div
+              key={virtualRow.index}
+              className={virtualRow.index % 2 ? 'ListItemOdd' : 'ListItemEven'}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100px',
+                height: `${rows[virtualRow.index]}px`,
+                transform: `translate(${virtualRow.column * 100}px, ${
+                  virtualRow.start
+                }px)`,
+              }}
+            >
+              Row {virtualRow.index}
+            </div>
           ))}
         </div>
       </div>

--- a/examples/react/variable/src/main.tsx
+++ b/examples/react/variable/src/main.tsx
@@ -35,8 +35,12 @@ function App() {
       <GridVirtualizerVariable rows={rows} columns={columns} />
       <br />
       <br />
-      <h3>Masonry</h3>
-      <MasonryVirtualizerVariable rows={rows} />
+      <h3>Masonry (vertical)</h3>
+      <MasonryVerticalVirtualizerVariable rows={rows} />
+      <br />
+      <br />
+      <h3>Masonry (horizontal)</h3>
+      <MasonryHorizontalVirtualizerVariable rows={rows} />
       <br />
       <br />
       {process.env.NODE_ENV === 'development' ? (
@@ -223,7 +227,7 @@ function GridVirtualizerVariable({ rows, columns }) {
   )
 }
 
-function MasonryVirtualizerVariable({ rows }) {
+function MasonryVerticalVirtualizerVariable({ rows }) {
   const parentRef = React.useRef()
 
   const rowVirtualizer = useVirtualizer({
@@ -259,15 +263,67 @@ function MasonryVirtualizerVariable({ rows }) {
               style={{
                 position: 'absolute',
                 top: 0,
-                left: 0,
-                width: '100px',
+                left: `${virtualRow.column * 25}%`,
+                width: '25%',
                 height: `${rows[virtualRow.index]}px`,
-                transform: `translate(${virtualRow.column * 100}px, ${
-                  virtualRow.start
-                }px)`,
+                transform: `translateY(${virtualRow.start}px)`,
               }}
             >
               Row {virtualRow.index}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function MasonryHorizontalVirtualizerVariable({ rows }) {
+  const parentRef = React.useRef()
+
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: columns.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (i) => columns[i],
+    overscan: 5,
+    columns: 4,
+  })
+
+  return (
+    <>
+      <div
+        ref={parentRef}
+        className="List"
+        style={{
+          width: `500px`,
+          height: `400px`,
+          overflow: 'auto',
+        }}
+      >
+        <div
+          style={{
+            width: `${columnVirtualizer.getTotalSize()}px`,
+            height: '100%',
+            position: 'relative',
+          }}
+        >
+          {columnVirtualizer.getVirtualItems().map((virtualColumn) => (
+            <div
+              key={virtualColumn.index}
+              className={
+                virtualColumn.index % 2 ? 'ListItemOdd' : 'ListItemEven'
+              }
+              style={{
+                position: 'absolute',
+                top: `${virtualColumn.column * 25}%`,
+                left: 0,
+                height: '25%',
+                width: `${columns[virtualColumn.index]}px`,
+                transform: `translateX(${virtualColumn.start}px)`,
+              }}
+            >
+              Column {virtualColumn.index}
             </div>
           ))}
         </div>

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -34,7 +34,7 @@ export interface VirtualItem {
   start: number
   end: number
   size: number
-  column: number
+  lane: number
 }
 
 interface Rect {
@@ -262,7 +262,7 @@ export interface VirtualizerOptions<
   scrollingDelay?: number
   indexAttribute?: string
   initialMeasurementsCache?: VirtualItem[]
-  columns?: number
+  lanes?: number
 }
 
 export class Virtualizer<
@@ -347,7 +347,7 @@ export class Virtualizer<
       scrollingDelay: 150,
       indexAttribute: 'data-index',
       initialMeasurementsCache: [],
-      columns: 1,
+      lanes: 1,
       ...opts,
     }
   }
@@ -473,29 +473,29 @@ export class Virtualizer<
         for (let m = i - 1; m >= 0; m--) {
           const measurement = measurements[m]!
 
-          if (furthestMeasurementsFound.has(measurement.column)) {
+          if (furthestMeasurementsFound.has(measurement.lane)) {
             continue
           }
 
           const previousFurthestMeasurement = furthestMeasurements.get(
-            measurement.column,
+            measurement.lane,
           )
           if (
             previousFurthestMeasurement == null ||
             measurement.end > previousFurthestMeasurement.end
           ) {
-            furthestMeasurements.set(measurement.column, measurement)
+            furthestMeasurements.set(measurement.lane, measurement)
           } else if (measurement.end < previousFurthestMeasurement.end) {
-            furthestMeasurementsFound.set(measurement.column, true)
+            furthestMeasurementsFound.set(measurement.lane, true)
           }
 
-          if (furthestMeasurementsFound.size === this.options.columns) {
+          if (furthestMeasurementsFound.size === this.options.lanes) {
             break
           }
         }
 
         const furthestMeasurement =
-          furthestMeasurements.size === this.options.columns
+          furthestMeasurements.size === this.options.lanes
             ? Array.from(furthestMeasurements.values()).sort(
                 (a, b) => a.end - b.end,
               )[0]
@@ -513,9 +513,9 @@ export class Virtualizer<
 
         const end = start + size
 
-        const column = furthestMeasurement
-          ? furthestMeasurement.column
-          : i % this.options.columns
+        const lane = furthestMeasurement
+          ? furthestMeasurement.lane
+          : i % this.options.lanes
 
         measurements[i] = {
           index: i,
@@ -523,7 +523,7 @@ export class Virtualizer<
           size,
           end,
           key,
-          column,
+          lane,
         }
       }
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -458,10 +458,6 @@ export class Virtualizer<
     measurements: VirtualItem[],
     index: number,
   ) => {
-    if (this.options.lanes === 1) {
-      return measurements[index - 1]
-    }
-
     const furthestMeasurementsFound = new Map<number, true>()
     const furthestMeasurements = new Map<number, VirtualItem>()
     for (let m = index - 1; m >= 0; m--) {
@@ -509,7 +505,10 @@ export class Virtualizer<
       for (let i = min; i < count; i++) {
         const key = getItemKey(i)
 
-        const furthestMeasurement = this.getFurthestMeasurement(measurements, i)
+        const furthestMeasurement =
+          this.options.lanes === 1
+            ? measurements[i - 1]
+            : this.getFurthestMeasurement(measurements, i)
 
         const start = furthestMeasurement
           ? furthestMeasurement.end

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -468,34 +468,41 @@ export class Virtualizer<
       for (let i = min; i < count; i++) {
         const key = getItemKey(i)
 
-        const complete = new Map<number, true>()
-        const columns = new Map<number, VirtualItem>()
+        const furthestMeasurementsFound = new Map<number, true>()
+        const furthestMeasurements = new Map<number, VirtualItem>()
         for (let m = i - 1; m >= 0; m--) {
           const measurement = measurements[m]!
 
-          if (complete.has(measurement.column)) {
+          if (furthestMeasurementsFound.has(measurement.column)) {
             continue
           }
 
-          const previous = columns.get(measurement.column)
-          if (previous == null || measurement.end > previous.end) {
-            columns.set(measurement.column, measurement)
-          } else if (measurement.end < previous.end) {
-            complete.set(measurement.column, true)
+          const previousFurthestMeasurement = furthestMeasurements.get(
+            measurement.column,
+          )
+          if (
+            previousFurthestMeasurement == null ||
+            measurement.end > previousFurthestMeasurement.end
+          ) {
+            furthestMeasurements.set(measurement.column, measurement)
+          } else if (measurement.end < previousFurthestMeasurement.end) {
+            furthestMeasurementsFound.set(measurement.column, true)
           }
 
-          if (complete.size === this.options.columns) {
+          if (furthestMeasurementsFound.size === this.options.columns) {
             break
           }
         }
 
-        const beforeMeasurement =
-          columns.size === this.options.columns
-            ? Array.from(columns.values()).sort((a, b) => a.end - b.end)[0]
+        const furthestMeasurement =
+          furthestMeasurements.size === this.options.columns
+            ? Array.from(furthestMeasurements.values()).sort(
+                (a, b) => a.end - b.end,
+              )[0]
             : undefined
 
-        const start = beforeMeasurement
-          ? beforeMeasurement.end
+        const start = furthestMeasurement
+          ? furthestMeasurement.end
           : paddingStart + scrollMargin
 
         const measuredSize = itemSizeCache.get(key)
@@ -506,8 +513,8 @@ export class Virtualizer<
 
         const end = start + size
 
-        const column = beforeMeasurement
-          ? beforeMeasurement.column
+        const column = furthestMeasurement
+          ? furthestMeasurement.column
           : i % this.options.columns
 
         measurements[i] = {

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -474,24 +474,24 @@ export class Virtualizer<
         const complete = new Map<number, true>()
         const columns = new Map<number, VirtualItem>()
         for (let m = i - 1; m >= 0; m--) {
-          if (complete.size === this.options.columns) {
-            break
-          }
-
           const measurement = measurements[m]!
-          const index = this.options.horizontal
+          const key = this.options.horizontal
             ? measurement.top
             : measurement.left
 
-          if (complete.has(index)) {
+          if (complete.has(key)) {
             continue
           }
 
-          const previous = columns.get(index)
+          const previous = columns.get(key)
           if (previous == null || measurement.end > previous.end) {
-            columns.set(index, measurement)
+            columns.set(key, measurement)
           } else if (measurement.end < previous.end) {
-            complete.set(index, true)
+            complete.set(key, true)
+          }
+
+          if (complete.size === this.options.columns) {
+            break
           }
         }
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -34,8 +34,7 @@ export interface VirtualItem {
   start: number
   end: number
   size: number
-  top: number
-  left: number
+  column: number
 }
 
 interface Rect {
@@ -264,7 +263,6 @@ export interface VirtualizerOptions<
   indexAttribute?: string
   initialMeasurementsCache?: VirtualItem[]
   columns?: number
-  columnsSize?: number
 }
 
 export class Virtualizer<
@@ -350,7 +348,6 @@ export class Virtualizer<
       indexAttribute: 'data-index',
       initialMeasurementsCache: [],
       columns: 1,
-      columnsSize: 0,
       ...opts,
     }
   }
@@ -475,19 +472,16 @@ export class Virtualizer<
         const columns = new Map<number, VirtualItem>()
         for (let m = i - 1; m >= 0; m--) {
           const measurement = measurements[m]!
-          const key = this.options.horizontal
-            ? measurement.top
-            : measurement.left
 
-          if (complete.has(key)) {
+          if (complete.has(measurement.column)) {
             continue
           }
 
-          const previous = columns.get(key)
+          const previous = columns.get(measurement.column)
           if (previous == null || measurement.end > previous.end) {
-            columns.set(key, measurement)
+            columns.set(measurement.column, measurement)
           } else if (measurement.end < previous.end) {
-            complete.set(key, true)
+            complete.set(measurement.column, true)
           }
 
           if (complete.size === this.options.columns) {
@@ -512,25 +506,17 @@ export class Virtualizer<
 
         const end = start + size
 
+        const column = beforeMeasurement
+          ? beforeMeasurement.column
+          : i % this.options.columns
+
         measurements[i] = {
           index: i,
           start,
           size,
           end,
           key,
-          ...(this.options.horizontal
-            ? {
-                top: beforeMeasurement
-                  ? beforeMeasurement.top
-                  : i * this.options.columnsSize,
-                left: start,
-              }
-            : {
-                top: start,
-                left: beforeMeasurement
-                  ? beforeMeasurement.left
-                  : i * this.options.columnsSize,
-              }),
+          column,
         }
       }
 


### PR DESCRIPTION
This PR aims at adding support to masonry layouts as expressed in #30

In terms of logic the difference is that instead of taking the previous element in the list, it looks for the one that's the furthest away from the end of the container.

For example in a top to bottom list with two columns and these elements:

```
----------- -----------
|    1    | |    2    |
|         | -----------
-----------
```

The third element should be inserted below box 2 and not box 1 because box 2 is the one that's the furthest from the end of the container.

```
----------- -----------
|    1    | |    2    |
|         | -----------
----------- -----------
            |    3    |
            |         |
            -----------
```

The fourth element would be inserted below box 1.

I updated the docs and added an example to the variable examples:

https://user-images.githubusercontent.com/2291025/222973210-ecba891e-3848-4093-8b2c-79c1b901b017.mov

