### PR TITLE
Add force option in observeElementOffset callback for more intricate scrolling requirements

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -179,7 +179,7 @@ export const measureElement = <TItemElement extends Element>(
   }
   return Math.round(
     element.getBoundingClientRect()[
-      instance.options.horizontal ? 'width' : 'height'
+    instance.options.horizontal ? 'width' : 'height'
     ],
   )
 }
@@ -237,7 +237,7 @@ export interface VirtualizerOptions<
   ) => void | (() => void)
   observeElementOffset: (
     instance: Virtualizer<TScrollElement, TItemElement>,
-    cb: (offset: number) => void,
+    cb: (offset: number, force?: boolean) => void,
   ) => void | (() => void)
 
   // Optional
@@ -340,7 +340,7 @@ export class Virtualizer<
       horizontal: false,
       getItemKey: defaultKeyExtractor,
       rangeExtractor: defaultRangeExtractor,
-      onChange: () => {},
+      onChange: () => { },
       measureElement,
       initialRect: { width: 0, height: 0 },
       scrollMargin: 0,
@@ -398,7 +398,7 @@ export class Virtualizer<
       )
 
       this.unsubs.push(
-        this.options.observeElementOffset(this, (offset) => {
+        this.options.observeElementOffset(this, (offset, force) => {
           this.scrollAdjustments = 0
 
           if (this.scrollOffset === offset) {
@@ -415,7 +415,7 @@ export class Virtualizer<
             this.scrollOffset < offset ? 'forward' : 'backward'
           this.scrollOffset = offset
 
-          this.maybeNotify()
+          this.maybeNotify(force)
 
           this.isScrollingTimeoutId = setTimeout(() => {
             this.isScrollingTimeoutId = null
@@ -486,8 +486,8 @@ export class Virtualizer<
 
     return furthestMeasurements.size === this.options.lanes
       ? Array.from(furthestMeasurements.values()).sort(
-          (a, b) => a.end - b.end,
-        )[0]
+        (a, b) => a.end - b.end,
+      )[0]
       : undefined
   }
 
@@ -705,12 +705,12 @@ export class Virtualizer<
 
     return notUndefined(
       measurements[
-        findNearestBinarySearch(
-          0,
-          measurements.length - 1,
-          (index: number) => notUndefined(measurements[index]).start,
-          offset,
-        )
+      findNearestBinarySearch(
+        0,
+        measurements.length - 1,
+        (index: number) => notUndefined(measurements[index]).start,
+        offset,
+      )
       ],
     )
   }

--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -15,13 +15,13 @@ export function memo<TDeps extends readonly any[], TResult>(
   let deps = opts.initialDeps ?? []
   let result: TResult | undefined
 
-  return (): TResult => {
+  return (force?: boolean): TResult => {
     let depTime: number
     if (opts.key && opts.debug?.()) depTime = Date.now()
 
     const newDeps = getDeps()
 
-    const depsChanged =
+    const depsChanged = force ||
       newDeps.length !== deps.length ||
       newDeps.some((dep: any, index: number) => deps[index] !== dep)
 
@@ -55,9 +55,9 @@ export function memo<TDeps extends readonly any[], TResult>(
             font-size: .6rem;
             font-weight: bold;
             color: hsl(${Math.max(
-              0,
-              Math.min(120 - 120 * resultFpsPercentage, 120),
-            )}deg 100% 31%);`,
+          0,
+          Math.min(120 - 120 * resultFpsPercentage, 120),
+        )}deg 100% 31%);`,
         opts?.key,
       )
     }


### PR DESCRIPTION
In practice, this is a tiny addition to the memoization mechanism which could come in handy for more use-cases in the future.

The main drive behind it was to enable a smooth push-out transition between sections, demonstrated in this [CodeSandbox](https://codesandbox.io/p/sandbox/crazy-shadow-lllc2y) based on the original Sticky example. The existing mechanism optimizes updates based on `range` changes, but in this case, the two section headers collide "mid-item" making the transition inconsistent and jumpy (even more so when having different item sizes per type of row, like in this example).

Another option would be to make `Virtualizer.notify` public, but this solution plays nicer with `observeElementOffset` and feels more principled.