### PR TITLE
(Fix) calling useWindowVirtulizer reset's page scroll to 0

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -187,7 +187,7 @@ export const measureElement = <TItemElement extends Element>(
 export const windowScroll = <T extends Window>(
   offset: number,
   {
-    adjustments = 0,
+    adjustments = window.scrollY,
     behavior,
   }: { adjustments?: number; behavior?: ScrollBehavior },
   instance: Virtualizer<T, any>,


### PR DESCRIPTION
If a user scrolls the page before `useWindowVirtualizer` is called, the scroll position will be reset to 0. This fixes that issue.