### PR TITLE
Use correct hook name on Introduction page

### DIFF
--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -11,14 +11,14 @@ At the heart of TanStack Virtual is the `Virtualizer`. Virtualizers can be orien
 Here is just a quick example of what it looks like to virtualize a long list within a div using TanStack Virtual in React:
 
 ```tsx
-import { useVirtual } from '@tanstack/react-virtual';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 function App() {
   // The scrollable element for your list
   const parentRef = React.useRef()
 
   // The virtualizer
-  const rowVirtualizer = useVirtual({
+  const rowVirtualizer = useVirtualizer({
     count: 10000,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 35,


### PR DESCRIPTION
Introduction page of the documentation has the mention of incorrect hook - `useVirtual`, which is not present in the code. `useVirtualizer` name should be used instead.