### PR TITLE
Update documentation of `resizeItem`

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -288,7 +288,7 @@ By default the `measureElement` virtualizer option is configured to measure elem
 ### `resizeItem`
 
 ```tsx
-resizeItem: (index: number, size: number) => void
+resizeItem: (item: VirtualItem, size: number) => void
 ```
 
 Change the virtualized item's size manually. Use this function to manually set the size calculated for this item. Useful in occations when using some custom morphing transition and you know the morphed item's size beforehand.


### PR DESCRIPTION
# Pull Request

There is currently a mismatch of the documentation and the definition/handling in the code regarding the `resizeItem` method which is utilized to adjust the size of an item. 

![Screenshot 2023-12-18 at 13 44 38](https://github.com/TanStack/virtual/assets/1060490/784a8df5-9604-42f9-9552-62859df69bdb)

After a prior update (https://github.com/TanStack/virtual/commit/3270b6c38a6ea699f36e72a05729b274a6c5335b) the first [argument](https://github.com/TanStack/virtual/blob/62d6dc8cf917e8500b4709a59a46f936d9252f61/packages/virtual-core/src/index.ts#L651) got changed from being an item index (= `number`) to a reference of an `virtualItem` itself. With the alignment in the docs it consistency in usage will be ensured.

![Screenshot 2023-12-18 at 13 48 45](https://github.com/TanStack/virtual/assets/1060490/f5a28bfa-86df-4b13-9de8-02e342b874fe)
