### PR TITLE
Bug Fix: Calculate getTotalSize correctly when using multiple lanes

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -861,11 +861,24 @@ export class Virtualizer<
     })
   }
 
-  getTotalSize = () =>
-    (this.getMeasurements()[this.options.count - 1]?.end ||
-      this.options.paddingStart) -
+  getTotalSize = () => {
+    const measurements = this.getMeasurements();
+
+    let end: number;
+    // If there are no measurements, set the end to paddingStart
+    if (measurements.length === 0) {
+      end = this.options.paddingStart;
+    } else {
+      // If lanes is 1, use the last measurement's end, otherwise find the maximum end value among all measurements
+      end = this.options.lanes === 1 
+      ? (measurements[measurements.length - 1]?.end ?? 0)
+      : Math.max(...measurements.map((m) => m.end));
+    }
+
+   return end -
     this.options.scrollMargin +
     this.options.paddingEnd
+  }
 
   private _scrollToOffset = (
     offset: number,

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -872,7 +872,7 @@ export class Virtualizer<
       // If lanes is 1, use the last measurement's end, otherwise find the maximum end value among all measurements
       end = this.options.lanes === 1 
       ? (measurements[measurements.length - 1]?.end ?? 0)
-      : Math.max(...measurements.map((m) => m.end));
+      : Math.max(...measurements.slice(-this.options.lanes).map((m) => m.end));
     }
 
    return end -


### PR DESCRIPTION
In my application I have a waterfall style layout so the last item is not guaranteed to be the furthest away. I was having issues with the sizing not being correct, so after digging in I found the root cause and implemented a fix.

Example of my measurements array (look at the last 2 items and notice the 2nd to last has a greater end property):
<img width="792" alt="virtual" src="https://github.com/TanStack/virtual/assets/15990084/ee3c5557-023d-4188-810d-b9e44dd3b9e9">

I also included a small optimization for one lane. I am happy to tweak the logic in any way so just let me know. Happy to contribute!