### PR TITLE
fix: error while running tsc with --declaration flag

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -37,7 +37,7 @@ export interface VirtualItem {
   lane: number
 }
 
-interface Rect {
+export interface Rect {
   width: number
   height: number
 }


### PR DESCRIPTION
Encountered an error while running `tsc` with the `--declaration` flag:

`Exported variable 'x' has or is using name 'Rect' from external module "node_modules/@tanstack/virtual-core/build/lib/index" but cannot be named.`

Fix is to simply export related interface from index.ts