### PR TITLE
feat: detect scroll completion with scrollend event

### DIFF
--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -77,3 +77,11 @@ export function notUndefined<T>(value: T | undefined, msg?: string): T {
 }
 
 export const approxEqual = (a: number, b: number) => Math.abs(a - b) < 1
+
+export const debounce = (fn: Function, ms: number) => {
+  let timeoutId: ReturnType<typeof setTimeout>
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => fn.apply(this, args), ms)
+  }
+}


### PR DESCRIPTION
As scrollend event is supported by almost all major browser ( without safari ) we can use it to detect scroll completion, in this change the observeElementOffset type signature changed, current it will be not only responsible to return scroll offset but also if is scrolling.

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event
https://developer.chrome.com/blog/scrollend-a-new-javascript-event/