### PR TITLE
Run watcher post DOM update in Vue adapter

### DIFF
--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -61,7 +61,7 @@ function useVirtualizerBase<
     },
     {
       immediate: true,
-      flush: 'post'
+      flush: 'post',
     },
   )
 

--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -61,6 +61,7 @@ function useVirtualizerBase<
     },
     {
       immediate: true,
+      flush: 'post'
     },
   )
 


### PR DESCRIPTION
This solves https://github.com/TanStack/virtual/issues/715

According to the [Vue docs](https://vuejs.org/guide/essentials/watchers.html#callback-flush-timing); watchers will run their effects after state updates but before DOM updates. The `ref` attribute performs the same way which is why some users discovered they need to wrap their `measureElement` calls with `nextTick` in order to measure elements in a post update state (https://github.com/TanStack/virtual/issues/619).

Currently the vue adapter will update state pre DOM update which causes an infinite loop if the estimated size of an element doesn't exactly match the measured size. Simply running the effect post DOM update will ensure that the elements are measured and taken into account before virtualizer updates its state. 