### PR TITLE
Don't run state effects in Vue immediately

### DIFF
--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -61,7 +61,7 @@ function useVirtualizerBase<
     },
     {
       immediate: true,
-      flush: 'post'
+      flush: 'post',
     },
   )
 

--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -61,6 +61,7 @@ function useVirtualizerBase<
     },
     {
       immediate: true,
+      flush: 'post'
     },
   )
 

--- a/packages/vue-virtual/src/index.ts
+++ b/packages/vue-virtual/src/index.ts
@@ -60,7 +60,6 @@ function useVirtualizerBase<
       triggerRef(state)
     },
     {
-      immediate: true,
       flush: 'post',
     },
   )


### PR DESCRIPTION
Also related to https://github.com/TanStack/virtual/issues/715.

The previous PR https://github.com/TanStack/virtual/pull/716 partially solved the issue by not entering an infinite loop if the elements resized after the virtualizer had mounted but the issue persisted if the virtualizer had just mounted and the effect was running for the first time.

Confirmed in the codesandbox attached to the issue and my own project that this solves the issue.