### PR TITLE
docs(virtualizer): update scrollToFn/Offset/Index options

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -141,7 +141,7 @@ This function receives visible range indexes and should return array of indexes 
 ```tsx
 scrollToFn?: (
   offset: number,
-  canSmooth: boolean,
+  options: { adjustments?: number; behavior?: 'auto' | 'smooth' },
   instance: Virtualizer<TScrollElement, TItemElement>,
 ) => void
 ```
@@ -254,7 +254,7 @@ scrollToOffset: (
   toOffset: number,
   options?: {
     align?: 'start' | 'center' | 'end' | 'auto',
-    smoothScroll?: boolean
+    behavior?: 'auto' | 'smooth'
   }
 ) => void
 ```
@@ -268,7 +268,7 @@ scrollToIndex: (
   index: number,
   options?: {
     align?: 'start' | 'center' | 'end' | 'auto',
-    smoothScroll?: boolean
+    behavior?: 'auto' | 'scroll'
   }
 ) => void
 ```


### PR DESCRIPTION
In https://github.com/TanStack/virtual/pull/439 (possibly previous commits)`scrollTo*` options argument was changed but docs weren't updated.