### PR TITLE
examples(react): remove missing link in react dynamic example

### DIFF
--- a/examples/react/dynamic/src/main.tsx
+++ b/examples/react/dynamic/src/main.tsx
@@ -295,9 +295,6 @@ function App() {
             <a href="/">List</a>
           </li>
           <li>
-            <a href="/window-list">List - window as scroller</a>
-          </li>
-          <li>
             <a href="/columns">Column</a>
           </li>
           <li>


### PR DESCRIPTION
I found an invalid link in example code.
So I removed it.

The `window-list` example was moved to another page in #614 .
It seems the item was just forgotten to be deleted.
