### PR TITLE
docs: update installation commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,29 +9,29 @@ Install your TanStack Virtual adapter as a dependency using your favorite npm pa
 ## React Virtual
 
 ```bash
-$ npm install @tanstack/react-virtual
+npm install @tanstack/react-virtual
 ```
 
 ## Solid Virtual
 
 ```bash
-$ npm install @tanstack/solid-virtual
+npm install @tanstack/solid-virtual
 ```
 
 ## Svelte Virtual
 
 ```bash
-$ npm install @tanstack/svelte-virtual
+npm install @tanstack/svelte-virtual
 ```
 
 ## Vue Virtual
 
 ```bash
-$ npm install @tanstack/vue-virtual
+npm install @tanstack/vue-virtual
 ```
 
 ## Virtual Core (no framework)
 
 ```bash
-$ npm install @tanstack/virtual-core
+npm install @tanstack/virtual-core
 ```


### PR DESCRIPTION
As "Copy" button copies the whole content, `$ npm install ...` would copy the dollar sign too, but it's redundant and not a valid command to run. I removed it to keep consistent and provide the best UX for tanstack users.