### PR TITLE
docs: remove "coming soon" from Vue Virtual docs title

### DIFF
--- a/docs/framework/vue/vue-virtual.md
+++ b/docs/framework/vue/vue-virtual.md
@@ -1,5 +1,5 @@
 ---
-title: Vue Virtual (Coming Soon)
+title: Vue Virtual
 ---
 
 The `@tanstack/vue-virtual` adapter is a wrapper around the core virtual logic.


### PR DESCRIPTION
Vue Virtual is released now, so this "coming soon" text seemed appropriate to remove.