### PR TITLE
feat: add measureElement on virtual item, when we can't relay on node.isConnected

### DIFF
--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -5,12 +5,13 @@ title: VirtualItem
 The `VirtualItem` object represents a single item returned by the virtualizer. It contains information you need to render the item in the coordinate space within your virtualizer's scrollElement and other helpful properties/functions.
 
 ```tsx
-export interface VirtualItem {
+export interface VirtualItem<TItemElement extends Element> {
   key: string | number
   index: number
   start: number
   end: number
   size: number
+  measureElement: (node: TItemElement | null | undefined) => void
 }
 ```
 

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -321,10 +321,10 @@ By default the `measureElement` virtualizer option is configured to measure elem
 ### `resizeItem`
 
 ```tsx
-resizeItem: (item: VirtualItem, size: number) => void
+resizeItem: (index: number, size: number) => void
 ```
 
-Change the virtualized item's size manually. Use this function to manually set the size calculated for this item. Useful in occations when using some custom morphing transition and you know the morphed item's size beforehand.
+Change the virtualized item's size manually. Use this function to manually set the size calculated for this index. Useful in occations when using some custom morphing transition and you know the morphed item's size beforehand.
 
 You can also use this method with a throttled ResizeObserver instead of `Virtualizer.measureElement` to reduce re-rendering.
 


### PR DESCRIPTION
As we can relay on node.isConnected to attach the RO or read size, like in `lit` integration https://github.com/TanStack/virtual/pull/718 we need to have another option to do. In this PR  https://github.com/TanStack/virtual/pull/737 let's add back the measureElement on virtual item and keep it stale via measureElementCache that has bound in scope index.


```
${ref(virtualRow.measureElement}
``` 