### PR TITLE
fix(virtual-core): add support to multi window

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -353,7 +353,7 @@ export class Virtualizer<
         return _ro
       }
 
-      if (typeof ResizeObserver === 'undefined' || !this.targetWindow) {
+      if (!this.targetWindow || !this.targetWindow.ResizeObserver) {
         return null
       }
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -67,6 +67,10 @@ export const observeElementRect = <T extends Element>(
   if (!element) {
     return
   }
+  const targetWindow = element.ownerDocument.defaultView
+  if (!targetWindow) {
+    return
+  }
 
   const handler = (rect: Rect) => {
     const { width, height } = rect
@@ -79,7 +83,7 @@ export const observeElementRect = <T extends Element>(
     return () => {}
   }
 
-  const observer = new ResizeObserver((entries) => {
+  const observer = new targetWindow.ResizeObserver((entries) => {
     const entry = entries[0]
     if (entry?.borderBoxSize) {
       const box = entry.borderBoxSize[0]
@@ -134,13 +138,21 @@ export const observeElementOffset = <T extends Element>(
   if (!element) {
     return
   }
+  const targetWindow = element.ownerDocument.defaultView
+  if (!targetWindow) {
+    return
+  }
 
   let offset = 0
   const fallback = supportsScrollend
     ? () => undefined
-    : debounce(() => {
-        cb(offset, false)
-      }, instance.options.isScrollingResetDelay)
+    : debounce(
+        targetWindow,
+        () => {
+          cb(offset, false)
+        },
+        instance.options.isScrollingResetDelay,
+      )
 
   const createHandler = (isScrolling: boolean) => () => {
     offset = element[instance.options.horizontal ? 'scrollLeft' : 'scrollTop']
@@ -168,13 +180,21 @@ export const observeWindowOffset = (
   if (!element) {
     return
   }
+  const targetWindow = element.window
+  if (!targetWindow) {
+    return
+  }
 
   let offset = 0
   const fallback = supportsScrollend
     ? () => undefined
-    : debounce(() => {
-        cb(offset, false)
-      }, instance.options.isScrollingResetDelay)
+    : debounce(
+        targetWindow,
+        () => {
+          cb(offset, false)
+        },
+        instance.options.isScrollingResetDelay,
+      )
 
   const createHandler = (isScrolling: boolean) => () => {
     offset = element[instance.options.horizontal ? 'scrollX' : 'scrollY']
@@ -307,8 +327,9 @@ export class Virtualizer<
   private unsubs: (void | (() => void))[] = []
   options!: Required<VirtualizerOptions<TScrollElement, TItemElement>>
   scrollElement: TScrollElement | null = null
+  private targetWindow: (Window & typeof globalThis) | null = null
   isScrolling: boolean = false
-  private scrollToIndexTimeoutId: ReturnType<typeof setTimeout> | null = null
+  private scrollToIndexTimeoutId: number | null = null
   measurementsCache: VirtualItem[] = []
   private itemSizeCache = new Map<Key, number>()
   private pendingMeasuredCacheIndexes: number[] = []
@@ -330,15 +351,17 @@ export class Virtualizer<
     const get = () => {
       if (_ro) {
         return _ro
-      } else if (typeof ResizeObserver !== 'undefined') {
-        return (_ro = new ResizeObserver((entries) => {
-          entries.forEach((entry) => {
-            this._measureElement(entry.target as TItemElement, entry)
-          })
-        }))
-      } else {
+      }
+
+      if (typeof ResizeObserver === 'undefined' || !this.targetWindow) {
         return null
       }
+
+      return (_ro = new this.targetWindow.ResizeObserver((entries) => {
+        entries.forEach((entry) => {
+          this._measureElement(entry.target as TItemElement, entry)
+        })
+      }))
     }
 
     return {
@@ -431,6 +454,12 @@ export class Virtualizer<
       this.cleanup()
 
       this.scrollElement = scrollElement
+
+      if (this.scrollElement && 'ownerDocument' in this.scrollElement) {
+        this.targetWindow = this.scrollElement.ownerDocument.defaultView
+      } else {
+        this.targetWindow = this.scrollElement?.window ?? null
+      }
 
       this._scrollToOffset(this.scrollOffset, {
         adjustments: undefined,
@@ -807,8 +836,8 @@ export class Virtualizer<
   private isDynamicMode = () => this.measureElementCache.size > 0
 
   private cancelScrollToIndex = () => {
-    if (this.scrollToIndexTimeoutId !== null) {
-      clearTimeout(this.scrollToIndexTimeoutId)
+    if (this.scrollToIndexTimeoutId !== null && this.targetWindow) {
+      this.targetWindow.clearTimeout(this.scrollToIndexTimeoutId)
       this.scrollToIndexTimeoutId = null
     }
   }
@@ -849,8 +878,8 @@ export class Virtualizer<
 
     this._scrollToOffset(toOffset, { adjustments: undefined, behavior })
 
-    if (behavior !== 'smooth' && this.isDynamicMode()) {
-      this.scrollToIndexTimeoutId = setTimeout(() => {
+    if (behavior !== 'smooth' && this.isDynamicMode() && this.targetWindow) {
+      this.scrollToIndexTimeoutId = this.targetWindow.setTimeout(() => {
         this.scrollToIndexTimeoutId = null
 
         const elementInDOM = this.measureElementCache.has(

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -67,7 +67,7 @@ export const observeElementRect = <T extends Element>(
   if (!element) {
     return
   }
-  const targetWindow = element.ownerDocument.defaultView
+  const targetWindow = instance.targetWindow
   if (!targetWindow) {
     return
   }
@@ -138,7 +138,7 @@ export const observeElementOffset = <T extends Element>(
   if (!element) {
     return
   }
-  const targetWindow = element.ownerDocument.defaultView
+  const targetWindow = instance.targetWindow
   if (!targetWindow) {
     return
   }
@@ -180,7 +180,7 @@ export const observeWindowOffset = (
   if (!element) {
     return
   }
-  const targetWindow = element.window
+  const targetWindow = instance.targetWindow
   if (!targetWindow) {
     return
   }
@@ -327,7 +327,7 @@ export class Virtualizer<
   private unsubs: (void | (() => void))[] = []
   options!: Required<VirtualizerOptions<TScrollElement, TItemElement>>
   scrollElement: TScrollElement | null = null
-  private targetWindow: (Window & typeof globalThis) | null = null
+  targetWindow: (Window & typeof globalThis) | null = null
   isScrolling: boolean = false
   private scrollToIndexTimeoutId: number | null = null
   measurementsCache: VirtualItem[] = []

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -79,7 +79,7 @@ export const observeElementRect = <T extends Element>(
 
   handler(element.getBoundingClientRect())
 
-  if (typeof ResizeObserver === 'undefined') {
+  if (!targetWindow.ResizeObserver) {
     return () => {}
   }
 

--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -78,10 +78,14 @@ export function notUndefined<T>(value: T | undefined, msg?: string): T {
 
 export const approxEqual = (a: number, b: number) => Math.abs(a - b) < 1
 
-export const debounce = (fn: Function, ms: number) => {
-  let timeoutId: ReturnType<typeof setTimeout>
+export const debounce = (
+  targetWindow: Window & typeof globalThis,
+  fn: Function,
+  ms: number,
+) => {
+  let timeoutId: number
   return function (this: any, ...args: any[]) {
-    clearTimeout(timeoutId)
-    timeoutId = setTimeout(() => fn.apply(this, args), ms)
+    targetWindow.clearTimeout(timeoutId)
+    timeoutId = targetWindow.setTimeout(() => fn.apply(this, args), ms)
   }
 }


### PR DESCRIPTION
 
## Overview

In multi window environment, where React is running in a main window/process and renders content to a different child window, the globals like `setTimeout`/`clearTimeout` will not work properly because it's using the main Window object and not the child one.

This PR adds support to multi-window.
`setTimeout` --> `targetWindow.setTimeout`
`clearTimeout` --> `targetWindow.clearTimeout`
`ResizeObserver` --> `targetWindow.ResizeObserver`

`targetWindow` is obtained from `scrollElement.ownerDocument.defaultView`. 


## More details
We have multi-windows use case, so we want to make sure that the globals work well with it. This is the reason for my PR.

I built an example of dynamic height list in child window:
https://stackblitz.com/edit/vitejs-vite-2zau9t?file=src%2FApp.tsx&terminal=dev
1. Open this example on Chrome/Edge
2. Popout the example in a new tab
3. Click 'Open Child Window' button, a child window opens and a dynamic height virtual list is visible
4. Open devtools on child window, modify the content of Row 0. 
5. Notice the resize did not get triggered immediately. It triggers after 5-10 seconds. 
(Note that this happens only when the child window is opened for the first time from the main window. This inconsistent behavior came from browser.)



I tried the same example with my change, and the resize is triggered immediately.

- Before

https://github.com/TanStack/virtual/assets/28751745/8831ecaf-2633-40a0-8244-2e40ac8044d7

- After

https://github.com/TanStack/virtual/assets/28751745/2871cb72-fd11-432f-9c3a-fd6974e659f1



>We are switching to @tanstack/react-virtual for our virtualized lists because we find its api very appealing! 
This is my first time contributing to tanstack. I appreciate your feedbacks!
