### PR TITLE
docs: update API documentation of scrollToIndex

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -276,7 +276,7 @@ scrollToIndex: (
   index: number,
   options?: {
     align?: 'start' | 'center' | 'end' | 'auto',
-    behavior?: 'auto' | 'scroll'
+    behavior?: 'auto' | 'smooth'
   }
 ) => void
 ```


### PR DESCRIPTION
The interface defines that the scroll behavior of the `scrollToIndex` function can be 'auto' or 'smooth'.

The documentation falsly stated 'auto' or 'scroll'