### PR TITLE
replace 'scroll' with 'smooth' for scrollToIndex

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -276,7 +276,7 @@ scrollToIndex: (
   index: number,
   options?: {
     align?: 'start' | 'center' | 'end' | 'auto',
-    behavior?: 'auto' | 'scroll'
+    behavior?: 'auto' | 'smooth'
   }
 ) => void
 ```


### PR DESCRIPTION
Just realized there is a slight error in the Docs. 'smooth' is the actual option and not 'scroll'. 