### PR TITLE
feat: Support inverted horizontal scrolling for right-to-left locales

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -227,6 +227,14 @@ This option allows you to specify the duration to wait after the last scroll eve
 
 The implementation of this option is driven by the need for a reliable mechanism to handle scrolling behavior across different browsers. Until all browsers uniformly support the scrollEnd event.
 
+### `isRtl`
+
+```tsx
+isRtl: boolean
+```
+
+Whether to invert horizontal scrolling to support right-to-left language locales.
+
 ## Virtualizer Instance
 
 The following properties and methods are available on the virtualizer instance:

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -156,7 +156,10 @@ export const observeElementOffset = <T extends Element>(
       )
 
   const createHandler = (isScrolling: boolean) => () => {
-    offset = element[instance.options.horizontal ? 'scrollLeft' : 'scrollTop']
+    const { horizontal, isRtl } = instance.options
+    offset = horizontal
+      ? element['scrollLeft'] * (isRtl && -1 || 1)
+      : element['scrollTop']
     fallback()
     cb(offset, isScrolling)
   }
@@ -320,6 +323,7 @@ export interface VirtualizerOptions<
   lanes?: number
   isScrollingResetDelay?: number
   enabled?: boolean
+  isRtl?: boolean
 }
 
 export class Virtualizer<
@@ -405,6 +409,7 @@ export class Virtualizer<
       lanes: 1,
       isScrollingResetDelay: 150,
       enabled: true,
+      isRtl: false,
       ...opts,
     }
   }

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -158,7 +158,7 @@ export const observeElementOffset = <T extends Element>(
   const createHandler = (isScrolling: boolean) => () => {
     const { horizontal, isRtl } = instance.options
     offset = horizontal
-      ? element['scrollLeft'] * (isRtl && -1 || 1)
+      ? element['scrollLeft'] * ((isRtl && -1) || 1)
       : element['scrollTop']
     fallback()
     cb(offset, isScrolling)


### PR DESCRIPTION
This change adds an option for consumers who need to switch between left-to-right and right-to-left language locales. 

With this change, scrolling left-to-right:
https://github.com/user-attachments/assets/93892f15-a5fe-4cdc-8ccf-45c316a966f0

Without this change, scrolling right-to-left:
https://github.com/user-attachments/assets/47aa1cae-de3d-4946-9fd8-29fee19fe560

With this change, scrolling right-to-left:
https://github.com/user-attachments/assets/ab87e0f7-0679-4669-986d-69188d572f7f

