### PR TITLE
Correct key for getVirtualItems memo

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -825,7 +825,7 @@ export class Virtualizer<
       return virtualItems
     },
     {
-      key: process.env.NODE_ENV !== 'production' && 'getIndexes',
+      key: process.env.NODE_ENV !== 'production' && 'getVirtualItems',
       debug: () => this.options.debug,
     },
   )


### PR DESCRIPTION
This PR corrected key for the `getVirtualItems` memo.