### PR TITLE
Improve Solid adapter.

### DIFF
--- a/packages/solid-virtual/src/index.tsx
+++ b/packages/solid-virtual/src/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tanstack/virtual-core'
 
 import {
-  createComputed,
+  createEffect,
   createSignal,
   mergeProps,
   onCleanup,
@@ -55,22 +55,19 @@ function createVirtualizerBase<
   }
 
   const virtualizer = new Proxy(instance, handler)
-  virtualizer.setOptions(resolvedOptions)
 
   onMount(() => {
     const cleanup = virtualizer._didMount()
-    virtualizer._willUpdate()
     onCleanup(cleanup)
   })
 
-  createComputed(() => {
+  createEffect(() => {
     virtualizer.setOptions(
       mergeProps(resolvedOptions, options, {
         onChange: (
           instance: Virtualizer<TScrollElement, TItemElement>,
           sync: boolean,
         ) => {
-          instance._willUpdate()
           setVirtualItems(
             reconcile(instance.getVirtualItems(), {
               key: 'index',
@@ -81,6 +78,8 @@ function createVirtualizerBase<
         },
       }),
     )
+    setVirtualItems([])
+    virtualizer._willUpdate()
     virtualizer.measure()
   })
 


### PR DESCRIPTION
I encountered some issues using the Solid adapter with the latest Solid version (1.8). In particular, no items would display unless I added into my code a deferred setting of the element ref (e.g. `ref={(el) => queueMicrotask(() => setRef(el))}`). 

Looking through the source I believe the issue stems from `_willUpdate` being called with a `scrollElement` that has not yet been connected to a `targetWindow` (due to the use of `createComputed`). This PR attempts to avoid this issue and the need for a workaround in consumer code as well as make a few other changes for optimisation and to maintain reactivity expectations.

--

Use `createEffect` to ensure scrollElement ref is connected to DOM and ownerDocument/window before attempting to update measurements for it. Otherwise, `virtualizer.targetWindow` will be set to null (in _willUpdate), the scrollElement rect to nothing and no items will be displayed.

In addition, remove some logic that causes redundant work to be done (e.g. `setOptions` called multiple times, `_willUpdate` called on mount which is a no-op if the scollElement didn't change). Instead rely on the options reactivity to perform the bulk of the work.

Also, reset virtual items store when options change to ensure that reactivity is maintained - e.g. so that `measureItem` is called again in a `<For>` loop if `scrollMargin` changed.