### PR TITLE
fix(angular-virtual): fix build & remove unused scripts

### DIFF
--- a/packages/angular-virtual/package.json
+++ b/packages/angular-virtual/package.json
@@ -37,17 +37,12 @@
     "node": ">=12"
   },
   "files": [
-    "build",
-    "!**/*.d.ts",
-    "!**/*.d.ts.map"
+    "build"
   ],
   "scripts": {
     "clean": "rimraf ./build",
     "test:types": "tsc --noEmit",
-    "build": "ng-packagr -p ng-package.json -c tsconfig.build.json",
-    "build-no-package-json": "pnpm run build && rimraf ./build/package.json",
-    "BAK": "ng-packagr -p ng-package.json -c tsconfig.build.json",
-    "build:types": "tsc --emitDeclarationOnly"
+    "build": "ng-packagr -p ng-package.json -c tsconfig.build.json"
   },
   "dependencies": {
     "@tanstack/virtual-core": "workspace:*",


### PR DESCRIPTION
Excluding .d.ts files from the package output results in TypeScript errors for consumers trying to install @tanstack/angular-virtual.

For example:

![image](https://github.com/user-attachments/assets/58b73b88-6f21-42be-a4fc-1f99a4f5e6f7)

(from https://tanstack.com/virtual/latest/docs/framework/angular/examples/fixed)

This was a simple copy/paste error that I only noticed after the package was published, since the .d.ts files are present locally and only get excluded by the actual npm publish.