### PR TITLE
chore: change type of `debug` from `any` to `boolean`

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -296,7 +296,7 @@ export interface VirtualizerOptions<
   ) => void | (() => void)
 
   // Optional
-  debug?: any
+  debug?: boolean
   initialRect?: Rect
   onChange?: (
     instance: Virtualizer<TScrollElement, TItemElement>,

--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -7,7 +7,7 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
   fn: (...args: NoInfer<[...TDeps]>) => TResult,
   opts: {
     key: false | string
-    debug?: () => any
+    debug?: () => boolean
     onChange?: (result: TResult) => void
     initialDeps?: TDeps
   },


### PR DESCRIPTION
Hi, I checked the type of debug and it's`any`. But [this link](https://tanstack.com/virtual/latest/docs/api/virtualizer#debug) says boolean type, and I didn't understand why it was of type `any` either. so I changed it to boolean.