### PR TITLE
fix(angular-virtual): fix proxying of computed functions with args

### DIFF
--- a/packages/angular-virtual/src/proxy.ts
+++ b/packages/angular-virtual/src/proxy.ts
@@ -63,7 +63,7 @@ export function proxyVirtualizer<
           'indexFromElement',
         ].includes(property)
       ) {
-        const fn = untypedTarget[property] as Function
+        const fn = virtualizer[property as keyof V] as Function
         Object.defineProperty(untypedTarget, property, {
           value: toComputed(virtualizerSignal, fn),
           configurable: true,


### PR DESCRIPTION
Calls to 'getOffsetForAlignment', getOffsetForIndex', 'getVirtualItemForOffset', and 'indexFromElement' now work as expected instead of erroring with `TypeError: fn is not a function`.