### PR TITLE
fix(virtual-core): add bigint to Key to align with @types/react implementation

### DIFF
--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -6,7 +6,7 @@ The `VirtualItem` object represents a single item returned by the virtualizer. I
 
 ```tsx
 export interface VirtualItem {
-  key: string | number
+  key: string | number | bigint
   index: number
   start: number
   end: number
@@ -19,7 +19,7 @@ The following properties and methods are available on each VirtualItem object:
 ### `key`
 
 ```tsx
-key: string | number
+key: string | number | bigint
 ```
 
 The unique key for the item. By default this is the item index, but should be configured via the `getItemKey` Virtualizer option.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -26,7 +26,7 @@ export interface Range {
   count: number
 }
 
-type Key = number | string
+type Key = number | string | bigint
 
 export interface VirtualItem {
   key: Key


### PR DESCRIPTION
This PR enhances `Key` type with `bigint` to align with `React.Key`. This was updated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66723. This will enable us to use `React.Key` as type for where we require `Key` as type. 