### PR TITLE
fix: When using initialRect, the first rendered nodes do not observe ResizeObserver.

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -47,7 +47,8 @@ function useVirtualizerBase<
   }, [])
 
   useIsomorphicLayoutEffect(() => {
-    return instance._willUpdate()
+    instance._willUpdate()
+    instance.measureElement = instance.measureElement.bind(instance)
   })
 
   return instance


### PR DESCRIPTION
This fix changes the reference to `instance.measureElement` so that the ref callback is called again after `instance._willUpdate()` is called.

This PR resolves #815 .