### PR TITLE
fix(react-virtual): handle `scrollElement` cleanup after HMR

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -42,7 +42,7 @@ function useVirtualizerBase<
 
   instance.setOptions(resolvedOptions)
 
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     return instance._didMount()
   }, [])
 


### PR DESCRIPTION
When HMR is triggered `useEffect` cleanup function will call function returned from `instance._didMount()`.
This will set `scrollElement` to null and `Virtualizer` will stop working.

I added an additional check if `scrollElement` is null and if it is - call `instance._willUpdate()`.

This PR resolves https://github.com/TanStack/virtual/issues/750.