### PR TITLE
docs(examples): fix bug in Vue infinite scroll example

### DIFF
--- a/examples/vue/infinite-scroll/src/App.vue
+++ b/examples/vue/infinite-scroll/src/App.vue
@@ -60,7 +60,7 @@ watchEffect(() => {
 
   if (
     lastItem.index >= allRows.value.length - 1 &&
-    hasNextPage &&
+    hasNextPage.value &&
     !isFetchingNextPage.value
   ) {
     fetchNextPage()


### PR DESCRIPTION
This fixes a ref not being accessed with it's `.value` accessor, causing a boolean check to always be truthy.