### PR TITLE
fix(virtual-core): Add option to disable element dimension rounding for improved scrolling precision

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -73,8 +73,14 @@ export const observeElementRect = <T extends Element>(
   }
 
   const handler = (rect: Rect) => {
-    const { width, height } = rect
-    cb({ width: Math.round(width), height: Math.round(height) })
+    let { width, height } = rect
+
+    if (instance.options.roundElementDimensions) {
+      width = Math.round(width)
+      height = Math.round(height)
+    }
+
+    cb({ width, height })
   }
 
   handler(element.getBoundingClientRect())
@@ -225,17 +231,26 @@ export const measureElement = <TItemElement extends Element>(
   if (entry?.borderBoxSize) {
     const box = entry.borderBoxSize[0]
     if (box) {
-      const size = Math.round(
-        box[instance.options.horizontal ? 'inlineSize' : 'blockSize'],
-      )
+      let size = box[instance.options.horizontal ? 'inlineSize' : 'blockSize']
+
+      if (instance.options.roundElementDimensions) {
+        size = Math.round(size)
+      }
+
       return size
     }
   }
-  return Math.round(
+
+  let size =
     element.getBoundingClientRect()[
       instance.options.horizontal ? 'width' : 'height'
-    ],
-  )
+    ]
+
+  if (instance.options.roundElementDimensions) {
+    size = Math.round(size)
+  }
+
+  return size
 }
 
 export const windowScroll = <T extends Window>(
@@ -323,6 +338,7 @@ export interface VirtualizerOptions<
   isScrollingResetDelay?: number
   enabled?: boolean
   isRtl?: boolean
+  roundElementDimensions?: boolean
 }
 
 export class Virtualizer<
@@ -412,6 +428,7 @@ export class Virtualizer<
       isScrollingResetDelay: 150,
       enabled: true,
       isRtl: false,
+      roundElementDimensions: true,
       ...opts,
     }
   }


### PR DESCRIPTION
This PR introduces a new `roundElementDimensions` prop to the `VirtualizerOptions`, allowing users to disable the default behavior of rounding element dimensions.

Problem:
Programmatic scrolling at the bottom of very large lists can become unstable when elements contain sub-pixel dimensions due to the default rounding of `getBoundingClientRect` values. This instability is particularly noticeable in lists with high precision layout requirements.

Solution:
The newly added `roundElementDimensions?: boolean` prop allows users to control whether element dimensions are rounded. By default, this prop is set to `true`, maintaining the current behavior. When set to `false`, rounding is skipped, ensuring more precise scrolling behavior in scenarios where sub-pixel accuracy is needed.