### PR TITLE
Fix(virtual-core): Wrap ResizeObserver callbacks in window.requestAnimationFrame to avoid error

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -84,15 +84,17 @@ export const observeElementRect = <T extends Element>(
   }
 
   const observer = new targetWindow.ResizeObserver((entries) => {
-    const entry = entries[0]
-    if (entry?.borderBoxSize) {
-      const box = entry.borderBoxSize[0]
-      if (box) {
-        handler({ width: box.inlineSize, height: box.blockSize })
-        return
+    window.requestAnimationFrame(() => {
+      const entry = entries[0]
+      if (entry?.borderBoxSize) {
+        const box = entry.borderBoxSize[0]
+        if (box) {
+          handler({ width: box.inlineSize, height: box.blockSize })
+          return
+        }
       }
-    }
-    handler(element.getBoundingClientRect())
+      handler(element.getBoundingClientRect())
+    })
   })
 
   observer.observe(element, { box: 'border-box' })
@@ -363,8 +365,10 @@ export class Virtualizer<
       }
 
       return (_ro = new this.targetWindow.ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-          this._measureElement(entry.target as TItemElement, entry)
+        window.requestAnimationFrame(() => {
+          entries.forEach((entry) => {
+            this._measureElement(entry.target as TItemElement, entry)
+          })
         })
       }))
     }


### PR DESCRIPTION
This PR wraps the two ResizeObserver callbacks with a window.requestAnimationFrame so that the "ResizeObserver loop completed with undelivered notifications" error doesn't happen.

Problem: ResizeObserver callbacks throw errors if they aren't able to resolve fully when they are invoked. This can happen if the callbacks are called at an inopportune time for the main thread, resulting in callbacks being dropped and the "ResizeObserver loop completed with undelivered notifications" error. This varies depending on how and when the resizes happened, and what browser you're on. I've found that Firefox is particularly picky about this.

Solution: There are several suggested [here](https://stackoverflow.com/questions/76187282/react-resizeobserver-loop-completed-with-undelivered-notifications). In my personal experience, window.requestAnimationFrame solves the problem pretty well. Wrapping the two callbacks in the ResizeObservers here resulted in the errors completely stopping for my use case.
