### PR TITLE
feat(virtual-core) add getVirtualIndexesAPI

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -286,6 +286,14 @@ type getVirtualItems = () => VirtualItem[]
 
 Returns the virtual items for the current state of the virtualizer.
 
+### `getVirtualIndexes`
+
+```tsx
+type getVirtualIndexes = () => number[]
+```
+
+Returns the virtual row indexes for the current state of the virtualizer.
+
 ### `scrollToOffset`
 
 ```tsx

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -696,7 +696,7 @@ export class Virtualizer<
     },
   )
 
-  private getIndexes = memo(
+  getVirtualIndexes = memo(
     () => {
       let startIndex: number | null = null
       let endIndex: number | null = null
@@ -724,7 +724,7 @@ export class Virtualizer<
           })
     },
     {
-      key: process.env.NODE_ENV !== 'production' && 'getIndexes',
+      key: process.env.NODE_ENV !== 'production' && 'getVirtualIndexes',
       debug: () => this.options.debug,
     },
   )
@@ -814,7 +814,7 @@ export class Virtualizer<
   }
 
   getVirtualItems = memo(
-    () => [this.getIndexes(), this.getMeasurements()],
+    () => [this.getVirtualIndexes(), this.getMeasurements()],
     (indexes, measurements) => {
       const virtualItems: Array<VirtualItem> = []
 


### PR DESCRIPTION
This pr exposes an API that used to be private (`getIndexes`) and makes it a new public API on the virtualizer called `getVirtualIndexes`.

For TanStack Table examples, I am exploring advanced virtualization performance techniques, and one of those strategies involves subscribing to APIs with less re-renders. For more fixed height virtual elements, this API should re-render a bit less.