### PR TITLE
docs: add missing parameter to onChange API

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -67,7 +67,7 @@ The initial `Rect` of the scrollElement. This is mostly useful if you need to ru
 ### `onChange`
 
 ```tsx
-onChange?: (instance: Virtualizer<TScrollElement, TItemElement>) => void
+onChange?: (instance: Virtualizer<TScrollElement, TItemElement>, sync: boolean) => void
 ```
 
 A callback function that fires when the virtualizer's internal state changes. It's passed the virtualizer instance.


### PR DESCRIPTION
## summary
the explanation of [onChange](https://tanstack.com/virtual/latest/docs/api/virtualizer#onchange) in the official documentation and the actual code do not match, as the sync parameter is missing.

so, i have modified the `docs/api/virtualizer.md` file.

## screenshot (docs)
[go to page](https://tanstack.com/virtual/latest/docs/api/virtualizer#onchange)
![image](https://github.com/user-attachments/assets/7f1c8c58-848d-4af1-8ee7-181990074640)

## source code
[go to line](https://github.com/TanStack/virtual/blob/7a3d541d55d7942b3202c1c38e3a9ab5f8ee86cd/packages/virtual-core/src/index.ts#L319)
```typescript
export interface VirtualizerOptions<
  TScrollElement extends Element | Window,
  TItemElement extends Element,
> {
  // omit other source code...
  onChange?: (
    instance: Virtualizer<TScrollElement, TItemElement>,
    sync: boolean,
  ) => void
```

