### PR TITLE
docs: add documentation for sync parameter of the onChange function.

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -67,7 +67,7 @@ The initial `Rect` of the scrollElement. This is mostly useful if you need to ru
 ### `onChange`
 
 ```tsx
-onChange?: (instance: Virtualizer<TScrollElement, TItemElement>) => void
+onChange?: (instance: Virtualizer<TScrollElement, TItemElement>, sync: boolean) => void
 ```
 
 A callback function that fires when the virtualizer's internal state changes. It's passed the virtualizer instance.

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -70,7 +70,9 @@ The initial `Rect` of the scrollElement. This is mostly useful if you need to ru
 onChange?: (instance: Virtualizer<TScrollElement, TItemElement>, sync: boolean) => void
 ```
 
-A callback function that fires when the virtualizer's internal state changes. It's passed the virtualizer instance.
+A callback function that fires when the virtualizer's internal state changes. It's passed the virtualizer instance and the sync parameter.
+
+The sync parameter indicates whether scrolling is currently in progress. It is `true` when scrolling is ongoing, and `false` when scrolling has stopped or other actions (such as resizing) are being performed.
 
 ### `overscan`
 


### PR DESCRIPTION
## summary

the description for the sync parameter of the `onChange` function was missing from the API documentation,
so I've added it.

upon reviewing the internal code, i found that it is invoked by the `notify` function.
> specifically through: `maybeNotify`, `resizeItem`, `measure`

## references

https://github.com/TanStack/virtual/blob/721bf538386482d201c1e1bff1a976c5997a90c9/packages/virtual-core/src/index.ts#L447

https://github.com/TanStack/virtual/blob/721bf538386482d201c1e1bff1a976c5997a90c9/packages/virtual-core/src/index.ts#L462

https://github.com/TanStack/virtual/blob/721bf538386482d201c1e1bff1a976c5997a90c9/packages/virtual-core/src/index.ts#L827

https://github.com/TanStack/virtual/blob/721bf538386482d201c1e1bff1a976c5997a90c9/packages/virtual-core/src/index.ts#L1072