### PR TITLE
fix(virtual-core): ensure all items render when content height is less than or equal to viewport height

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -456,7 +456,7 @@ export class Virtualizer<
         this.isScrolling,
         this.range ? this.range.startIndex : null,
         this.range ? this.range.endIndex : null,
-        this.scrollRect 
+        this.scrollRect,
       ]
     },
     (isScrolling) => {
@@ -469,7 +469,7 @@ export class Virtualizer<
         this.isScrolling,
         this.range ? this.range.startIndex : null,
         this.range ? this.range.endIndex : null,
-        this.scrollRect 
+        this.scrollRect,
       ] as [boolean, number | null, number | null, Rect],
     },
   )

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -456,6 +456,7 @@ export class Virtualizer<
         this.isScrolling,
         this.range ? this.range.startIndex : null,
         this.range ? this.range.endIndex : null,
+        this.scrollRect 
       ]
     },
     (isScrolling) => {
@@ -468,7 +469,8 @@ export class Virtualizer<
         this.isScrolling,
         this.range ? this.range.startIndex : null,
         this.range ? this.range.endIndex : null,
-      ] as [boolean, number | null, number | null],
+        this.scrollRect 
+      ] as [boolean, number | null, number | null, Rect],
     },
   )
 


### PR DESCRIPTION
Fixes #871 

## Problem:
This issue occurs because when the scroll container size (scrollRect) changes and the `maybeNotify` function is called, scrollRect is not included in the dependency array, causing the virtual item range to not be calculated correctly.

## Solution:
I added scrollRect value to the dependency array of the `maybeNotify` function, ensuring that the virtual item range is recalculated correctly when the scroll container size changes.
