### PR TITLE
fix(virtual-core): update maybeNotify cache when deps change

### DIFF
--- a/.changeset/mean-lamps-shake.md
+++ b/.changeset/mean-lamps-shake.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+fix(virtual-core): update maybeNotify cache when deps change

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -734,6 +734,7 @@ export class Virtualizer<
         startIndex = range.startIndex
         endIndex = range.endIndex
       }
+      this.maybeNotify.updateDeps([this.isScrolling, startIndex, endIndex])
       return [
         this.options.rangeExtractor,
         this.options.overscan,

--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -15,7 +15,7 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
   let deps = opts.initialDeps ?? []
   let result: TResult | undefined
 
-  return (): TResult => {
+  function memoizedFunction(): TResult {
     let depTime: number
     if (opts.key && opts.debug?.()) depTime = Date.now()
 
@@ -66,6 +66,13 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
 
     return result
   }
+
+  // Attach updateDeps to the function itself
+  memoizedFunction.updateDeps = (newDeps: [...TDeps]) => {
+    deps = newDeps
+  }
+
+  return memoizedFunction
 }
 
 export function notUndefined<T>(value: T | undefined, msg?: string): T {


### PR DESCRIPTION
The issue here was that rage was changed by getVirtualIndexes but that was not updating cache in maybeNotify that was it was not calling the notify. 

Fixes #871