### PR TITLE
fix(core): handle case when item count is less than or equal to lanes

### DIFF
--- a/.changeset/tall-masks-call.md
+++ b/.changeset/tall-masks-call.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/virtual-core": patch
+'@tanstack/virtual-core': patch
 ---
 
 fix(core): handle case when item count is less than or equal to lanes

--- a/.changeset/tall-masks-call.md
+++ b/.changeset/tall-masks-call.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/virtual-core": patch
+---
+
+fix(core): handle case when item count is less than or equal to lanes

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1123,6 +1123,14 @@ function calculateRange({
   const lastIndex = measurements.length - 1
   const getOffset = (index: number) => measurements[index]!.start
 
+  // handle case when item count is less than or equal to lanes
+  if (measurements.length <= lanes) {
+    return {
+      startIndex: 0,
+      endIndex: lastIndex,
+    }
+  }
+
   let startIndex = findNearestBinarySearch(
     0,
     lastIndex,


### PR DESCRIPTION
### Summary

This ensures calculateRange returns a valid range when there are fewer items than lanes (including single-item virtual lists). Prevents invalid access to undefined measurements and avoids empty or broken virtual ranges.

Fixes #963