### PR TITLE
fix(virtual-core): fix total size calculation for single item in multi-lane

### DIFF
--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1162,7 +1162,7 @@ function calculateRange({
     // Expand backward until we include all lanes' visible items
     // closer to the top
     const startPerLane = Array(lanes).fill(scrollOffset + outerSize)
-    while (startIndex > 0 && startPerLane.some((pos) => pos >= scrollOffset)) {
+    while (startIndex >= 0 && startPerLane.some((pos) => pos >= scrollOffset)) {
       const item = measurements[startIndex]!
       startPerLane[item.lane] = item.start
       startIndex--

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1046,7 +1046,7 @@ export class Virtualizer<
     } else {
       const endByLane = Array<number | null>(this.options.lanes).fill(null)
       let endIndex = measurements.length - 1
-      while (endIndex > 0 && endByLane.some((val) => val === null)) {
+      while (endIndex >= 0 && endByLane.some((val) => val === null)) {
         const item = measurements[endIndex]!
         if (endByLane[item.lane] === null) {
           endByLane[item.lane] = item.end

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -16,3 +16,16 @@ test('should return empty items for empty scroll element', () => {
   })
   expect(virtualizer.getVirtualItems()).toEqual([])
 })
+
+test('should return correct total size with one item and multiple lanes', () => {
+  const virtualizer = new Virtualizer({
+    count: 1,
+    lanes: 2,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  })
+  expect(virtualizer.getTotalSize()).toBe(50)
+})


### PR DESCRIPTION
This is a follow-up to #961. The original issue still occurs when there's only one item in a multi-lane layout.

This PR changes the loop condition in `getTotalSize()` to handle cases where only one item exists in multi-lane. The previous condition skipped the loop when `endIndex === 0`, which caused the total size to be incorrectly calculated as 0.

I used the following test to verify the fix locally:

```ts
test("should return correct total size with single item in multi-lane", () => {
  const virtualizer = new Virtualizer({
    count: 1,
    lanes: 2,
    getScrollElement: () => null,
    estimateSize: () => 50,
    scrollToFn: vi.fn(),
    observeElementRect: vi.fn(),
    observeElementOffset: vi.fn(),
  });
  expect(virtualizer.getTotalSize()).toBe(50);
});
```

This is a fairly specific edge case, so I didn’t include the test in the commit.
Happy to add it if you think it’d be useful to include in the suite!

Fixes #963