### PR TITLE
docs: update virtual table example with simplified and universal transform logic

### DIFF
--- a/examples/react/table/src/main.tsx
+++ b/examples/react/table/src/main.tsx
@@ -126,7 +126,7 @@ function ReactTableVirtualized() {
             ))}
           </thead>
           <tbody>
-            {virtualizer.getVirtualItems().map((virtualRow, index) => {
+            {virtualizer.getVirtualItems().map((virtualRow, index, virtualRows) => {
               const row = rows[virtualRow.index]
               return (
                 <tr
@@ -134,7 +134,7 @@ function ReactTableVirtualized() {
                   style={{
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${
-                      virtualRow.start - index * virtualRow.size
+                      virtualRows[0].start
                     }px)`,
                   }}
                 >


### PR DESCRIPTION
The current example works only for tables with equal row height and is unnecessarily complicated for static-positioned rows.

The proposed change is to use the first virtual row's start position of the current visible set for as a transform Y offset

**How it works**
For relatively positioned virtualized rows with dynamic or static heights, all currently rendered rows need to be offset by the starting position of the first virtual row in the current visible set. This offset (`virtualRows[0].start`) represents the accumulated height of all the virtual rows that have been rendered before the current set. By applying `translateY(${virtualRows[0].start}px)` to all rendered rows, we shift the entire visible block down to its correct starting point within the larger virtualized scrollable area.

**In simpler terms**: Imagine the entire virtual list. `virtualRows[0].start` tells us how far down we've scrolled. We then render a small window of rows. To place this window correctly, we need to shift the _entire window_ down by that scrolled amount. That's what translateY `${virtualRows[0].start}px` achieves for all the currently rendered rows.

How to test:
Apply the above change in this example and see it works:
https://tanstack.com/virtual/latest/docs/framework/react/examples/table

Make the height dynamic, and observe the example works for this variant
