### PR TITLE
Adapt default logic to adjust scroll position item size change

### DIFF
--- a/.changeset/petite-carrots-beam.md
+++ b/.changeset/petite-carrots-beam.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': minor
+---
+
+feat(virtual-core): change default condition to adjust scroll position on item size change

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -814,7 +814,7 @@ export class Virtualizer<
       if (
         this.shouldAdjustScrollPositionOnItemSizeChange !== undefined
           ? this.shouldAdjustScrollPositionOnItemSizeChange(item, delta, this)
-          : item.start < this.getScrollOffset() + this.scrollAdjustments
+          : this.scrollDirection === "backward" && item.start < this.getScrollOffset() + this.scrollAdjustments
       ) {
         if (process.env.NODE_ENV !== 'production' && this.options.debug) {
           console.info('correction', delta)


### PR DESCRIPTION
# Context

This change is based on those issues: #910, #562 
It tries to implement the idea from this message:
> @kmpeeduwee it's default behaviour, can be disabled using shouldAdjustScrollPositionOnItemSizeChange, please checkout docs https://tanstack.com/virtual/latest/docs/api/virtualizer#shouldadjustscrollpositiononitemsizechange
> 
> Overall we should change the logic to adjust position only on scrolling backward. 

 _Originally posted by @piecyk in [#910](https://github.com/TanStack/virtual/issues/910#issuecomment-2679300004)_
 
Disclaimer:  I'm not an expert of the lib, neither someone used to contribute a lot to open source (and/or on tanstack repositories)