### PR TITLE
feat(virtual-core): add `startItem` option

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -138,6 +138,14 @@ getItemKey?: (index: number) => Key
 
 This function is passed the index of each item and should return a unique key for that item. The default functionality of this function is to return the index of the item, but you should override this when possible to return a unique identifier for each item across the entire set. This function should be memoized to prevent unnecessary re-renders.
 
+### `startItem`
+
+```ts
+startItem?: (index: number) => number
+```
+
+This optional function is called when you need specials gaps between your items. This measurement should return the left or top of the item depending on `horizontal`. Useful when you know your layouts in advance.
+
 ### `rangeExtractor`
 
 ```tsx

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -337,6 +337,7 @@ export interface VirtualizerOptions<
   scrollPaddingEnd?: number
   initialOffset?: number | (() => number)
   getItemKey?: (index: number) => Key
+  startItem?: ((index: number) => number) | null
   rangeExtractor?: (range: Range) => Array<number>
   scrollMargin?: number
   gap?: number
@@ -431,6 +432,7 @@ export class Virtualizer<
       getItemKey: defaultKeyExtractor,
       rangeExtractor: defaultRangeExtractor,
       onChange: () => {},
+      startItem: null,
       measureElement,
       initialRect: { width: 0, height: 0 },
       scrollMargin: 0,
@@ -668,9 +670,11 @@ export class Virtualizer<
             ? measurements[i - 1]
             : this.getFurthestMeasurement(measurements, i)
 
-        const start = furthestMeasurement
-          ? furthestMeasurement.end + this.options.gap
-          : paddingStart + scrollMargin
+        const start =
+          this.options.startItem?.(i) ??
+          (furthestMeasurement
+            ? furthestMeasurement.end + this.options.gap
+            : paddingStart + scrollMargin)
 
         const measuredSize = itemSizeCache.get(key)
         const size =


### PR DESCRIPTION
## 🎯 Changes

The goal of this pr is to give the possibility to add a custom left or top for a virtual item.
Typical scenario: Having a horizontal timeline where every width can be a place for a start item.

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [X] I have tested and linted this code locally.
- [ ] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.
