### PR TITLE
fix(react-virtual): window virtualizer scroll persistence

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -84,7 +84,6 @@ export function useWindowVirtualizer<TItemElement extends Element>(
     observeElementRect: observeWindowRect,
     observeElementOffset: observeWindowOffset,
     scrollToFn: windowScroll,
-    initialOffset: () => (typeof document !== 'undefined' ? window.scrollY : 0),
     ...options,
   })
 }


### PR DESCRIPTION
🎯 **Changes**

Fix scroll position persistence in _useWindowVirtualizer_ when navigating between routes

This PR removes the automatic initialOffset: () => window.scrollY from useWindowVirtualizer that was causing
scroll position to persist incorrectly when navigating between routes in single-page applications.

**The Problem**

When using useWindowVirtualizer in a SPA with client-side routing:
1. User scrolls down on Route A (non-virtualized content)
2. User navigates to Route B (virtualized list)
3. Bug: Route B starts at the same scroll position as Route A instead of at the top

**Open issues:**

https://github.com/TanStack/virtual/issues/997
https://github.com/TanStack/router/issues/4107

**The Solution**

- Removed the default initialOffset: () => window.scrollY from useWindowVirtualizer
- The virtualizer now uses the default initialOffset of 0 (from virtual-core)
- Users can still explicitly set initialOffset when needed (e.g., for SSR)

**Tests Added**

- Test verifying useWindowVirtualizer doesn't set initialOffset from window.scrollY by default
- Test verifying users can still explicitly set initialOffset when needed

This change aligns with the API documentation which states that initialOffset is "usually only useful if you are
rendering the virtualizer in a SSR environment."

✅ **Checklist**

- I have followed the steps listed in the https://github.com/TanStack/config/blob/main/CONTRIBUTING.md.
- I have tested and linted this code locally.
- I have generated a https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for this PR,
or this PR should not release a new version.