### PR TITLE
docs: remove '$' from installation commands in Installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,13 +33,13 @@ npm install @tanstack/vue-virtual
 ## Lit Virtual
 
 ```bash
-$ npm install @tanstack/lit-virtual
+npm install @tanstack/lit-virtual
 ```
 
 ## Angular Virtual
 
 ```bash
-$ npm install @tanstack/angular-virtual
+npm install @tanstack/angular-virtual
 ```
 
 ## Virtual Core (no framework)


### PR DESCRIPTION
## 🎯 Changes

- Removed unnecessary '$' from installation command lines in the Installation documentation.
- Made command lines consistent and easier to copy for users.

| Before | After |
|:------:|:-----:|
|   <img width="789" height="443" alt="스크린샷 2025-08-31 오전 1 39 07" src="https://github.com/user-attachments/assets/b15666b9-5536-4616-bce4-e02b6ae149df" />|  <img width="800" height="444" alt="스크린샷 2025-08-31 오전 1 38 49" src="https://github.com/user-attachments/assets/6c972d0d-13e2-4e40-86b5-5ce737f606fe" />|

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [X] I have tested and linted this code locally.
- [ ] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.
