### PR TITLE
docs: update VirtualItem interface with lane property and correct measureElement reference

### DIFF
--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -11,6 +11,7 @@ export interface VirtualItem {
   start: number
   end: number
   size: number
+  lane: number
 }
 ```
 
@@ -54,7 +55,7 @@ The ending pixel offset for the item. This value is not necessary for most layou
 size: number
 ```
 
-The size of the item. This is usually mapped to a css property like `width/height`. Before an item is measured with the `VirtualItem.measureElement` method, this will be the estimated size returned from your `estimateSize` virtualizer option. After an item is measured (if you choose to measure it at all), this value will be the number returned by your `measureElement` virtualizer option (which by default is configured to measure elements with `getBoundingClientRect()`).
+The size of the item. This is usually mapped to a css property like `width/height`. Before an item is measured with the `Virtualizer.measureElement` method, this will be the estimated size returned from your `estimateSize` virtualizer option. After an item is measured (if you choose to measure it at all), this value will be the number returned by your `measureElement` virtualizer option (which by default is configured to measure elements with `getBoundingClientRect()`).
 
 ### `lane`
 


### PR DESCRIPTION
## 🎯 Changes

- Added the missing `lane` property to the `VirtualItem` interface to match its description.
- Corrected the reference of the `measureElement` method from `VirtualItem.measureElement` to `Virtualizer.measureElement` in the documentation.
- Verified and referenced the actual implementation in [`packages/virtual-core/src/index.ts`](https://github.com/TanStack/virtual/blob/main/packages/virtual-core/src/index.ts#L31) to ensure accuracy of the interface definition.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested and linted this code locally.
- [ ] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.
