### PR TITLE
docs: update Virtualizer types, fix measureElement method reference, and add optional modifiers

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -375,7 +375,7 @@ By default the `measureElement` virtualizer option is configured to measure elem
 resizeItem: (index: number, size: number) => void
 ```
 
-Change the virtualized item's size manually. Use this function to manually set the size calculated for this index. Useful in occations when using some custom morphing transition and you know the morphed item's size beforehand.
+Change the virtualized item's size manually. Use this function to manually set the size calculated for this index. Useful in occasions when using some custom morphing transition and you know the morphed item's size beforehand.
 
 You can also use this method with a throttled ResizeObserver instead of `Virtualizer.measureElement` to reduce re-rendering.
 


### PR DESCRIPTION
## 🎯 Changes

- Corrected types in the Virtualizer documentation to match the actual implementation found in [`VirtualizerOptions`](https://github.com/TanStack/virtual/blob/main/packages/virtual-core/src/index.ts#L297), [`Virtualizer`](https://github.com/TanStack/virtual/blob/main/packages/virtual-core/src/index.ts#L353).
- Fixed the incorrect reference of `virtualItem.measureElement` to the correct `Virtualizer.measureElement` method.
- Added missing optional (`?`) modifiers for optional options to maintain consistency and improve clarity for users.
- fix typo `occations` ➔ `occasions`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested and linted this code locally.
- [ ] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.