### PR TITLE
Fixed incorrect table height calculation, fixed some typing errors, reduced the amount of generated data to 1000

### DIFF
--- a/examples/vue/table/src/App.vue
+++ b/examples/vue/table/src/App.vue
@@ -6,66 +6,61 @@
       the translateY pixel count differently and base it off the index.
     </p>
 
-    <div ref="parentRef" class="container">
-      <div :style="{ height: `${totalSize}px` }">
-        <table>
-          <thead>
-            <tr
-              v-for="headerGroup in table.getHeaderGroups()"
-              :key="headerGroup.id"
+    <div class="container">
+      <table ref="parentRef" :style="{ height: `${totalSize}px` }">
+        <thead>
+        <tr
+          v-for="headerGroup in table.getHeaderGroups()"
+          :key="headerGroup.id"
+        >
+          <th
+            v-for="header in headerGroup.headers"
+            :key="header.id"
+            :colspan="header.colSpan"
+            :style="{ width: `${header.getSize()}px` }"
+          >
+            <div
+              v-if="!header.isPlaceholder"
+              :class="[
+                  'text-left',
+                  header.column.getCanSort()
+                    ? 'cursor-pointer select-none'
+                    : '',
+                ]"
+              @click="
+                  getSortingHandler(
+                    $event,
+                    header.column.getToggleSortingHandler(),
+                  )
+                "
             >
-              <th
-                v-for="header in headerGroup.headers"
-                :key="header.id"
-                :colspan="header.colSpan"
-                :style="{ width: `${header.getSize()}px` }"
-              >
-                <div
-                  v-if="!header.isPlaceholder"
-                  :class="[
-                    'text-left',
-                    header.column.getCanSort()
-                      ? 'cursor-pointer select-none'
-                      : '',
-                  ]"
-                  @click="
-                    getSortingHandler(
-                      $event,
-                      header.column.getToggleSortingHandler(),
-                    )
-                  "
-                >
-                  <FlexRender
-                    :render="header.column.columnDef.header"
-                    :props="header.getContext()"
-                  />
-                  <span v-if="header.column.getIsSorted() === 'asc'"> 🔼</span>
-                  <span v-if="header.column.getIsSorted() === 'desc'"> 🔽</span>
-                </div>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="(virtualRow, index) in virtualRows"
-              :key="virtualRow.key"
-              :style="{
-                transform: `translateY(${virtualRow.start - index * virtualRow.size}px)`,
-              }"
-            >
-              <td
-                v-for="cell in rows[virtualRow.index].getVisibleCells()"
-                :key="cell.id"
-              >
-                <FlexRender
-                  :render="cell.column.columnDef.cell"
-                  :props="cell.getContext()"
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+              <FlexRender
+                :render="header.column.columnDef.header"
+                :props="header.getContext()"
+              />
+              <span v-if="header.column.getIsSorted() === 'asc'"> 🔼</span>
+              <span v-if="header.column.getIsSorted() === 'desc'"> 🔽</span>
+            </div>
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr
+          v-for="(virtualRow, index) in virtualRows"
+          :key="index"
+        >
+          <td
+            v-for="cell in rows[virtualRow.index].getVisibleCells()"
+            :key="cell.id"
+          >
+            <FlexRender
+              :render="cell.column.columnDef.cell"
+              :props="cell.getContext()"
+            />
+          </td>
+        </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -75,15 +70,15 @@ import { ref, computed } from 'vue'
 import { useVirtualizer } from '@tanstack/vue-virtual'
 import {
   FlexRender,
-  ColumnDef,
-  SortingState,
+  type ColumnDef,
+  type SortingState,
   useVueTable,
   getCoreRowModel,
   getSortedRowModel,
 } from '@tanstack/vue-table'
-import { makeData, Person } from './makeData'
+import { makeData, type Person } from './makeData'
 
-const data = ref(makeData(50_000))
+const data = ref(makeData(1000))
 
 const sorting = ref<SortingState>([])
 
@@ -92,9 +87,7 @@ const getSortingHandler = (e: Event, fn: any) => {
 }
 
 const setSorting = (sortingUpdater: any) => {
-  const newSortVal = sortingUpdater(sorting.value)
-
-  sorting.value = newSortVal
+  sorting.value = sortingUpdater(sorting.value)
 }
 
 const columns = computed<ColumnDef<Person>[]>(() => {


### PR DESCRIPTION
## 🎯 Changes

When I redesigned my table based on the example, I noticed that the final height of the table was incorrectly determined. I started looking into it and it turned out that the parent link was set to the wrong element. When I installed it on a table element, the calculations began to proceed correctly. It's strange that during the last fix (https://github.com/TanStack/virtual/pull/887) they didn't find this problem and added a crutch :D

I also corrected some linter errors, but I don’t have time to deal with the typing of the sorting function, we’ll leave the decision to the next contributor :)

And I reduced the amount of generated data to 1000, I think it is obvious that there will be no difference between 1000 and 50000 in the display, but the page will take much longer to load.

https://github.com/TanStack/virtual/pull/887

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested and linted this code locally.
- [x] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.


