### PR TITLE
fix: stabilize lane assignments in masonry layout

### DIFF
--- a/.changeset/stable-lane-assignments.md
+++ b/.changeset/stable-lane-assignments.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/virtual-core": patch
+'@tanstack/virtual-core': patch
 ---
 
 fix: stabilize lane assignments in masonry layout
@@ -7,6 +7,7 @@ fix: stabilize lane assignments in masonry layout
 Added lane assignment caching to prevent items from jumping between lanes when viewport is resized. Previously, items could shift to different lanes during resize due to recalculating "shortest lane" with slightly different heights.
 
 Changes:
+
 - Added `laneAssignments` cache (Map<index, lane>) to persist lane assignments
 - Lane cache is cleared when `lanes` option changes or `measure()` is called
 - Lane cache is cleaned up when `count` decreases (removes stale entries)

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -624,7 +624,8 @@ export class Virtualizer<
       this.options.lanes,
     ],
     (count, paddingStart, scrollMargin, getItemKey, enabled, lanes) => {
-      const lanesChanged = this.prevLanes !== undefined && this.prevLanes !== lanes
+      const lanesChanged =
+        this.prevLanes !== undefined && this.prevLanes !== lanes
 
       if (lanesChanged) {
         // Set flag for getMeasurements to handle
@@ -689,11 +690,11 @@ export class Virtualizer<
       }
 
       // ✅ During lanes settling, ignore pendingMeasuredCacheIndexes to prevent repositioning
-      const min = this.lanesSettling ? 0 : (
-        this.pendingMeasuredCacheIndexes.length > 0
+      const min = this.lanesSettling
+        ? 0
+        : this.pendingMeasuredCacheIndexes.length > 0
           ? Math.min(...this.pendingMeasuredCacheIndexes)
           : 0
-      )
       this.pendingMeasuredCacheIndexes = []
 
       // ✅ End settling period when cache is fully built
@@ -704,7 +705,9 @@ export class Virtualizer<
       const measurements = this.measurementsCache.slice(0, min)
 
       // ✅ Performance: Track last item index per lane for O(1) lookup
-      const laneLastIndex: Array<number | undefined> = new Array(lanes).fill(undefined)
+      const laneLastIndex: Array<number | undefined> = new Array(lanes).fill(
+        undefined,
+      )
 
       // Initialize from existing measurements (before min)
       for (let m = 0; m < min; m++) {
@@ -726,7 +729,8 @@ export class Virtualizer<
           // Use cached lane - O(1) lookup for previous item in same lane
           lane = cachedLane
           const prevIndex = laneLastIndex[lane]
-          const prevInLane = prevIndex !== undefined ? measurements[prevIndex] : undefined
+          const prevInLane =
+            prevIndex !== undefined ? measurements[prevIndex] : undefined
           start = prevInLane
             ? prevInLane.end + this.options.gap
             : paddingStart + scrollMargin


### PR DESCRIPTION
Added lane assignment caching to prevent items from jumping between lanes when viewport is resized. Previously, items could shift to different lanes during resize due to recalculating "shortest lane" with slightly different heights.

## 🎯 Changes
- Added `laneAssignments` cache (Map<index, lane>) to persist lane assignments
- Lane cache is cleared when `lanes` option changes or `measure()` is called
- Lane cache is cleaned up when `count` decreases (removes stale entries)
- Lane cache is cleared when virtualizer is disabled


<!-- What changes are made in this PR? Is it a feature or a package submission? -->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested and linted this code locally.
- [x] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for this PR, or this PR should not release a new version.
