### PR TITLE
feat: add skipInitialOnChange to memo utility

### DIFF
--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -10,10 +10,12 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
     debug?: () => boolean
     onChange?: (result: TResult) => void
     initialDeps?: TDeps
+    skipInitialOnChange?: boolean
   },
 ) {
   let deps = opts.initialDeps ?? []
   let result: TResult | undefined
+  let isInitial = true
 
   function memoizedFunction(): TResult {
     let depTime: number
@@ -62,7 +64,11 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
       )
     }
 
-    opts?.onChange?.(result)
+    if (opts?.onChange && !(isInitial && opts.skipInitialOnChange)) {
+      opts.onChange(result)
+    }
+
+    isInitial = false
 
     return result
   }


### PR DESCRIPTION
## 🎯 Changes

Adds optional skipInitialOnChange flag to memo utility to prevent onChange
from firing on the first memoization, only on actual dependency changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
