### PR TITLE
feat(virtual-core): add laneAssignmentMode option

### DIFF
--- a/.changeset/loud-insects-itch.md
+++ b/.changeset/loud-insects-itch.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+feat(virtual-core): add deferLaneAssignment option

--- a/.changeset/loud-insects-itch.md
+++ b/.changeset/loud-insects-itch.md
@@ -1,5 +1,5 @@
 ---
-'@tanstack/virtual-core': patch
+'@tanstack/virtual-core': minor
 ---
 
-feat(virtual-core): add deferLaneAssignment option
+feat(virtual-core): add laneAssignmentMode option

--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -62,4 +62,5 @@ The size of the item. This is usually mapped to a css property like `width/heigh
 lane: number
 ```
 
-The lane index of the item. In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).
+The lane index of the item. Items are assigned to the shortest lane. Lane assignments are cached immediately based on the size measured by `estimateSize` by default; use `deferLaneAssignment: true` to base assignments on measured sizes instead.
+In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).

--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -62,5 +62,5 @@ The size of the item. This is usually mapped to a css property like `width/heigh
 lane: number
 ```
 
-The lane index of the item. Items are assigned to the shortest lane. Lane assignments are cached immediately based on the size measured by `estimateSize` by default; use `deferLaneAssignment: true` to base assignments on measured sizes instead.
+The lane index of the item. Items are assigned to the shortest lane. Lane assignments are cached immediately based on the size estimated by `estimateSize` by default; use `deferLaneAssignment: true` to base assignments on measured sizes instead.
 In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).

--- a/docs/api/virtual-item.md
+++ b/docs/api/virtual-item.md
@@ -62,5 +62,5 @@ The size of the item. This is usually mapped to a css property like `width/heigh
 lane: number
 ```
 
-The lane index of the item. Items are assigned to the shortest lane. Lane assignments are cached immediately based on the size estimated by `estimateSize` by default; use `deferLaneAssignment: true` to base assignments on measured sizes instead.
+The lane index of the item. Items are assigned to the shortest lane. Lane assignments are cached immediately based on the size estimated by `estimateSize` by default; set `laneAssignmentMode: 'measured'` to base assignments on measured sizes instead.
 In regular lists it will always be set to `0` but becomes useful for masonry layouts (see variable examples for more details).

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -232,7 +232,18 @@ This option allows you to set the spacing between items in the virtualized list.
 lanes: number
 ```
 
-The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists).
+The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists). Items are assigned to the lane with the shortest total size. Lane assignments are cached immediately based on `estimateSize` to prevent items from jumping between lanes.
+
+### `deferLaneAssignment`
+
+```tsx
+deferLaneAssignment?: boolean
+```
+
+**Default**: `false`
+
+When `true`, defers lane caching until items are measured via `measureElement`. This allows lane assignments to be based on actual measured sizes rather than `estimateSize`. After initial measurement, lanes are cached and remain stable.
+
 
 ### `isScrollingResetDelay`
 

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -230,7 +230,7 @@ This option allows you to set the spacing between items in the virtualized list.
 lanes: number
 ```
 
-The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists). Items are assigned to the lane with the shortest total size. Lane assignments are cached immediately based on `estimateSize` to prevent items from jumping between lanes.
+The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists). Items are assigned to the lane with the shortest total size. By default, when `deferLaneAssignment` is `false`, lane assignments are cached immediately based on `estimateSize` to prevent items from jumping between lanes (see `deferLaneAssignment` below to defer this behavior).
 
 ### `deferLaneAssignment`
 

--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -230,18 +230,20 @@ This option allows you to set the spacing between items in the virtualized list.
 lanes: number
 ```
 
-The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists). Items are assigned to the lane with the shortest total size. By default, when `deferLaneAssignment` is `false`, lane assignments are cached immediately based on `estimateSize` to prevent items from jumping between lanes (see `deferLaneAssignment` below to defer this behavior).
+The number of lanes the list is divided into (aka columns for vertical lists and rows for horizontal lists). Items are assigned to the lane with the shortest total size. By default, lane assignments are cached immediately based on `estimateSize` to prevent items from jumping between lanes (see `laneAssignmentMode` below to change this behavior).
 
-### `deferLaneAssignment`
+### `laneAssignmentMode`
 
 ```tsx
-deferLaneAssignment?: boolean
+laneAssignmentMode?: 'estimate' | 'measured'
 ```
 
-**Default**: `false`
+**Default**: `'estimate'`
 
-When `true`, defers lane caching until items are measured via `measureElement`. This allows lane assignments to be based on actual measured sizes rather than `estimateSize`. After initial measurement, lanes are cached and remain stable.
+Controls when lane assignments are cached in a masonry layout.
 
+- `'estimate'` (default): lane assignments are cached immediately based on `estimateSize`. This keeps items from jumping between lanes, but assignments may be suboptimal when the estimate is inaccurate.
+- `'measured'`: lane caching is deferred until items are measured via `measureElement`, so assignments reflect actual measured sizes. After the initial measurement, lanes are cached and remain stable.
 
 ### `isScrollingResetDelay`
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -292,6 +292,8 @@ export const elementScroll = <T extends Element>(
   })
 }
 
+type LaneAssignmentMode = 'estimate' | 'measured'
+
 export interface VirtualizerOptions<
   TScrollElement extends Element | Window,
   TItemElement extends Element,
@@ -346,7 +348,7 @@ export interface VirtualizerOptions<
   enabled?: boolean
   isRtl?: boolean
   useAnimationFrameWithResizeObserver?: boolean
-  deferLaneAssignment?: boolean
+  laneAssignmentMode?: LaneAssignmentMode
 }
 
 type ScrollState = {
@@ -477,7 +479,7 @@ export class Virtualizer<
       isRtl: false,
       useScrollendEvent: false,
       useAnimationFrameWithResizeObserver: false,
-      deferLaneAssignment: false,
+      laneAssignmentMode: 'estimate',
       ...opts,
     }
   }
@@ -729,9 +731,17 @@ export class Virtualizer<
       this.options.getItemKey,
       this.options.enabled,
       this.options.lanes,
-      this.options.deferLaneAssignment,
+      this.options.laneAssignmentMode,
     ],
-    (count, paddingStart, scrollMargin, getItemKey, enabled, lanes, deferLaneAssignment) => {
+    (
+      count,
+      paddingStart,
+      scrollMargin,
+      getItemKey,
+      enabled,
+      lanes,
+      laneAssignmentMode,
+    ) => {
       const lanesChanged =
         this.prevLanes !== undefined && this.prevLanes !== lanes
 
@@ -750,7 +760,7 @@ export class Virtualizer<
         getItemKey,
         enabled,
         lanes,
-        deferLaneAssignment,
+        laneAssignmentMode,
       }
     },
     {
@@ -761,7 +771,15 @@ export class Virtualizer<
   private getMeasurements = memo(
     () => [this.getMeasurementOptions(), this.itemSizeCache],
     (
-      { count, paddingStart, scrollMargin, getItemKey, enabled, lanes, deferLaneAssignment },
+      {
+        count,
+        paddingStart,
+        scrollMargin,
+        getItemKey,
+        enabled,
+        lanes,
+        laneAssignmentMode,
+      },
       itemSizeCache,
     ) => {
       if (!enabled) {
@@ -836,9 +854,9 @@ export class Virtualizer<
         let lane: number
         let start: number
 
-        // Check if this item has been measured (for deferLaneAssignment mode)
+        // Check if this item has been measured (for laneAssignmentMode)
         const isMeasured = itemSizeCache.has(key)
-        const shouldDeferLane = deferLaneAssignment && !isMeasured
+        const shouldDeferLane = laneAssignmentMode === 'measured' && !isMeasured
 
         if (cachedLane !== undefined && this.options.lanes > 1) {
           // Use cached lane - O(1) lookup for previous item in same lane

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -623,8 +623,9 @@ export class Virtualizer<
       this.options.getItemKey,
       this.options.enabled,
       this.options.lanes,
+      this.options.deferLaneAssignment,
     ],
-    (count, paddingStart, scrollMargin, getItemKey, enabled, lanes) => {
+    (count, paddingStart, scrollMargin, getItemKey, enabled, lanes, deferLaneAssignment) => {
       const lanesChanged =
         this.prevLanes !== undefined && this.prevLanes !== lanes
 
@@ -643,6 +644,7 @@ export class Virtualizer<
         getItemKey,
         enabled,
         lanes,
+        deferLaneAssignment,
       }
     },
     {
@@ -653,7 +655,7 @@ export class Virtualizer<
   private getMeasurements = memo(
     () => [this.getMeasurementOptions(), this.itemSizeCache],
     (
-      { count, paddingStart, scrollMargin, getItemKey, enabled, lanes },
+      { count, paddingStart, scrollMargin, getItemKey, enabled, lanes, deferLaneAssignment },
       itemSizeCache,
     ) => {
       if (!enabled) {
@@ -730,7 +732,7 @@ export class Virtualizer<
 
         // Check if this item has been measured (for deferLaneAssignment mode)
         const isMeasured = itemSizeCache.has(key)
-        const shouldDeferLane = this.options.deferLaneAssignment && !isMeasured
+        const shouldDeferLane = deferLaneAssignment && !isMeasured
 
         if (cachedLane !== undefined && this.options.lanes > 1) {
           // Use cached lane - O(1) lookup for previous item in same lane

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -854,9 +854,8 @@ export class Virtualizer<
         let lane: number
         let start: number
 
-        // Check if this item has been measured (for laneAssignmentMode)
-        const isMeasured = itemSizeCache.has(key)
-        const shouldDeferLane = laneAssignmentMode === 'measured' && !isMeasured
+        const shouldCacheLane =
+          laneAssignmentMode === 'estimate' || itemSizeCache.has(key)
 
         if (cachedLane !== undefined && this.options.lanes > 1) {
           // Use cached lane - O(1) lookup for previous item in same lane
@@ -882,8 +881,7 @@ export class Virtualizer<
             ? furthestMeasurement.lane
             : i % this.options.lanes
 
-          // Cache the lane assignment (skip if deferring and not yet measured)
-          if (this.options.lanes > 1 && !shouldDeferLane) {
+          if (this.options.lanes > 1 && shouldCacheLane) {
             this.laneAssignments.set(i, lane)
           }
         }

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -233,12 +233,12 @@ test('should not throw when component unmounts during scrollToIndex rAF loop', (
   }).not.toThrow()
 })
 
-test('should defer lane caching until measurement when deferLaneAssignment is true', () => {
+test("should defer lane caching until measurement when laneAssignmentMode is 'measured'", () => {
   const virtualizer = new Virtualizer({
     count: 4,
     lanes: 2,
     estimateSize: () => 100,
-    deferLaneAssignment: true,
+    laneAssignmentMode: 'measured',
     getScrollElement: () => null,
     scrollToFn: vi.fn(),
     observeElementRect: vi.fn(),
@@ -270,12 +270,12 @@ test('should defer lane caching until measurement when deferLaneAssignment is tr
   expect(lanesBeforeResize).toEqual(lanesAfterResize)
 })
 
-test('should cache lanes incrementally as items are measured with deferLaneAssignment', () => {
+test("should cache lanes incrementally as items are measured when laneAssignmentMode is 'measured'", () => {
   const virtualizer = new Virtualizer({
     count: 4,
     lanes: 2,
     estimateSize: () => 100,
-    deferLaneAssignment: true,
+    laneAssignmentMode: 'measured',
     getScrollElement: () => null,
     scrollToFn: vi.fn(),
     observeElementRect: vi.fn(),
@@ -307,11 +307,12 @@ test('should cache lanes incrementally as items are measured with deferLaneAssig
   expect(m2[1].lane).toBe(lane1)
 })
 
-test('should cache lanes immediately when deferLaneAssignment is false (default)', () => {
+test("should cache lanes immediately when laneAssignmentMode is 'estimate' (default)", () => {
   const virtualizer = new Virtualizer({
     count: 4,
     lanes: 2,
     estimateSize: () => 100,
+    laneAssignmentMode: 'estimate',
     getScrollElement: () => null,
     scrollToFn: vi.fn(),
     observeElementRect: vi.fn(),

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -270,6 +270,43 @@ test('should defer lane caching until measurement when deferLaneAssignment is tr
   expect(lanesBeforeResize).toEqual(lanesAfterResize)
 })
 
+test('should cache lanes incrementally as items are measured with deferLaneAssignment', () => {
+  const virtualizer = new Virtualizer({
+    count: 4,
+    lanes: 2,
+    estimateSize: () => 100,
+    deferLaneAssignment: true,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  })
+
+  virtualizer['getMeasurements']()
+  expect(virtualizer['laneAssignments'].size).toBe(0)
+
+  // Measure only the first 2 items (simulating viewport-visible items)
+  virtualizer.resizeItem(0, 200)
+  virtualizer.resizeItem(1, 50)
+
+  const m1 = virtualizer['getMeasurements']()
+  expect(virtualizer['laneAssignments'].size).toBe(2)
+
+  const lane0 = m1[0].lane
+  const lane1 = m1[1].lane
+
+  // Measure the remaining items
+  virtualizer.resizeItem(2, 80)
+  virtualizer.resizeItem(3, 120)
+
+  const m2 = virtualizer['getMeasurements']()
+  expect(virtualizer['laneAssignments'].size).toBe(4)
+
+  // Previously cached lanes must remain stable
+  expect(m2[0].lane).toBe(lane0)
+  expect(m2[1].lane).toBe(lane1)
+})
+
 test('should cache lanes immediately when deferLaneAssignment is false (default)', () => {
   const virtualizer = new Virtualizer({
     count: 4,


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

resolves #1114

Adds `deferLaneAssignment` option to defer lane caching until items are measured via `measureElement`.

#1080 introduced lane assignment caching based on `estimateSize` for visual stability. However, this broke a core use case for masonry layouts where lane assignments should be based on actual measured sizes, not estimates.

This PR adds a new option `deferLaneAssignment` (default: `false`):
- When `false` (default): Current behavior - lanes cached immediately from `estimateSize`
- When `true`: Lanes are calculated but not cached until first measurement, then cached based on actual sizes

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added laneAssignmentMode (default "estimate") to control when lane assignments are cached: estimate-now vs. defer until measured.

* **Documentation**
  * Updated lane/lanes docs to describe shortest-lane assignment, caching behavior, and the new laneAssignmentMode options.

* **Tests**
  * Added tests covering lane-assignment caching behavior for both modes.

* **Chores**
  * Prepared a minor release entry for this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->