### PR TITLE
feat: add e2e and perf tests for useExperimentalDOMVirtualizer with hook  injection

### DIFF
--- a/packages/react-virtual/e2e/app/measure-element/main.tsx
+++ b/packages/react-virtual/e2e/app/measure-element/main.tsx
@@ -41,7 +41,12 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
+        style={{
+          height: 400,
+          overflow: 'auto',
+          contain: 'strict',
+          overflowAnchor: 'none',
+        }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/measure-element/main.tsx
+++ b/packages/react-virtual/e2e/app/measure-element/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { useHook as useVirtualizer } from '../useHook'
 
 interface Item {
   id: string
@@ -41,7 +41,7 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto' }}
+        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/perf/index.html
+++ b/packages/react-virtual/e2e/app/perf/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/react-virtual/e2e/app/perf/main.tsx
+++ b/packages/react-virtual/e2e/app/perf/main.tsx
@@ -60,7 +60,12 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
+        style={{
+          height: 400,
+          overflow: 'auto',
+          contain: 'strict',
+          overflowAnchor: 'none',
+        }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/perf/main.tsx
+++ b/packages/react-virtual/e2e/app/perf/main.tsx
@@ -2,18 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { useHook as useVirtualizer } from '../useHook'
 
-function getRandomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min
-}
+const ITEM_COUNT = 10_000
 
 const randomHeight = (() => {
   const cache = new Map<string, number>()
   return (id: string) => {
     const value = cache.get(id)
-    if (value !== undefined) {
-      return value
-    }
-    const v = getRandomInt(25, 100)
+    if (value !== undefined) return value
+    const v = 25 + Math.floor(Math.random() * 76) // 25–100
     cache.set(id, v)
     return v
   }
@@ -21,71 +17,45 @@ const randomHeight = (() => {
 
 const App = () => {
   const parentRef = React.useRef<HTMLDivElement>(null)
+  const renderCount = React.useRef(0)
 
   const rowVirtualizer = useVirtualizer({
-    count: 1002,
+    count: ITEM_COUNT,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 50,
+  })
+
+  renderCount.current++
+
+  // Expose render count to Playwright
+  React.useEffect(() => {
+    ;(window as any).__RENDER_COUNT__ = renderCount
   })
 
   return (
     <div>
       <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
         <button
-          id="scroll-to-100"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(100, { behavior: 'smooth' })
-          }
+          id="scroll-to-5000"
+          onClick={() => rowVirtualizer.scrollToIndex(5000)}
         >
-          Smooth scroll to 100
+          Scroll to 5000
         </button>
         <button
-          id="scroll-to-500"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(500, { behavior: 'smooth' })
-          }
+          id="scroll-to-9999"
+          onClick={() => rowVirtualizer.scrollToIndex(ITEM_COUNT - 1)}
         >
-          Smooth scroll to 500
-        </button>
-        <button
-          id="scroll-to-1000"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(1000, { behavior: 'smooth' })
-          }
-        >
-          Smooth scroll to 1000
+          Scroll to last
         </button>
         <button
           id="scroll-to-0"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(0, { behavior: 'smooth' })
-          }
+          onClick={() => rowVirtualizer.scrollToIndex(0)}
         >
-          Smooth scroll to 0
-        </button>
-        <button
-          id="scroll-to-500-start"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(500, {
-              behavior: 'smooth',
-              align: 'start',
-            })
-          }
-        >
-          Smooth scroll to 500 (start)
-        </button>
-        <button
-          id="scroll-to-500-center"
-          onClick={() =>
-            rowVirtualizer.scrollToIndex(500, {
-              behavior: 'smooth',
-              align: 'center',
-            })
-          }
-        >
-          Smooth scroll to 500 (center)
+          Scroll to 0
         </button>
       </div>
+
+      <div id="render-count" data-renders={renderCount.current} />
 
       <div
         ref={parentRef}
@@ -123,4 +93,13 @@ const App = () => {
   )
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
+// Mark initial render timing
+performance.mark('app-start')
+const root = ReactDOM.createRoot(document.getElementById('root')!)
+root.render(<App />)
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    performance.mark('app-rendered')
+    performance.measure('initial-render', 'app-start', 'app-rendered')
+  })
+})

--- a/packages/react-virtual/e2e/app/scroll/main.tsx
+++ b/packages/react-virtual/e2e/app/scroll/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { useHook as useVirtualizer } from '../useHook'
 
 function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min
@@ -49,7 +49,7 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto' }}
+        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/scroll/main.tsx
+++ b/packages/react-virtual/e2e/app/scroll/main.tsx
@@ -49,7 +49,12 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
+        style={{
+          height: 400,
+          overflow: 'auto',
+          contain: 'strict',
+          overflowAnchor: 'none',
+        }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/smooth-scroll/main.tsx
+++ b/packages/react-virtual/e2e/app/smooth-scroll/main.tsx
@@ -90,7 +90,12 @@ const App = () => {
       <div
         ref={parentRef}
         id="scroll-container"
-        style={{ height: 400, overflow: 'auto', contain: 'strict', overflowAnchor: 'none' }}
+        style={{
+          height: 400,
+          overflow: 'auto',
+          contain: 'strict',
+          overflowAnchor: 'none',
+        }}
       >
         <div
           style={{

--- a/packages/react-virtual/e2e/app/test/fixtures.ts
+++ b/packages/react-virtual/e2e/app/test/fixtures.ts
@@ -1,0 +1,20 @@
+import { test as base, expect } from '@playwright/test'
+
+type HookVariant = 'standard' | 'experimental'
+
+export const test = base.extend<{ hookVariant: HookVariant }>({
+  hookVariant: ['standard', { option: true }],
+  page: async ({ page, hookVariant }, use) => {
+    const originalGoto = page.goto.bind(page)
+    page.goto = async function (url, options) {
+      if (hookVariant === 'experimental') {
+        const separator = url.includes('?') ? '&' : '?'
+        url = `${url}${separator}hook=experimental`
+      }
+      return originalGoto(url, options)
+    } as typeof page.goto
+    await use(page)
+  },
+})
+
+export { expect }

--- a/packages/react-virtual/e2e/app/test/measure-element.spec.ts
+++ b/packages/react-virtual/e2e/app/test/measure-element.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 test('positions items correctly after expand → collapse → delete → expand', async ({
   page,

--- a/packages/react-virtual/e2e/app/test/perf.spec.ts
+++ b/packages/react-virtual/e2e/app/test/perf.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test } from './fixtures'
+import type { Page } from '@playwright/test'
+
+async function getRenderCount(page: Page): Promise<number> {
+  return page.evaluate(() => (window as any).__RENDER_COUNT__?.current ?? 0)
+}
+
+async function collectScrollFPS(
+  page: Page,
+  scrollSteps: number,
+  stepPx: number,
+): Promise<{ fps: number; elapsed: number; renderCount: number }> {
+  const rendersBefore = await getRenderCount(page)
+
+  const result = await page.evaluate(
+    ([steps, px]) => {
+      return new Promise<{ fps: number; elapsed: number }>((resolve) => {
+        const container = document.querySelector('#scroll-container')!
+        let frames = 0
+        let step = 0
+        const start = performance.now()
+
+        function tick() {
+          container.scrollTop += px
+          frames++
+          step++
+          if (step < steps) {
+            requestAnimationFrame(tick)
+          } else {
+            // Wait one extra frame for final paint
+            requestAnimationFrame(() => {
+              const elapsed = performance.now() - start
+              resolve({ fps: (frames / elapsed) * 1000, elapsed })
+            })
+          }
+        }
+
+        requestAnimationFrame(tick)
+      })
+    },
+    [scrollSteps, stepPx] as const,
+  )
+
+  const rendersAfter = await getRenderCount(page)
+
+  return {
+    ...result,
+    renderCount: rendersAfter - rendersBefore,
+  }
+}
+
+test.describe('performance comparison', () => {
+  test('initial render time', async ({ page, hookVariant }) => {
+    await page.goto('/perf/')
+
+    // Wait for the initial render measurement to be recorded
+    await page.waitForFunction(
+      () => performance.getEntriesByName('initial-render').length > 0,
+    )
+
+    const duration = await page.evaluate(
+      () => performance.getEntriesByName('initial-render')[0].duration,
+    )
+
+    const renders = await getRenderCount(page)
+
+    console.log(
+      `[${hookVariant}] Initial render: ${duration.toFixed(1)}ms, renders: ${renders}`,
+    )
+
+    // Sanity check — initial render should be under 500ms
+    expect(duration).toBeLessThan(500)
+  })
+
+  test('continuous scroll performance (200 frames × 100px)', async ({
+    page,
+    hookVariant,
+  }) => {
+    await page.goto('/perf/')
+    await page.waitForTimeout(500) // settle
+
+    const { fps, elapsed, renderCount } = await collectScrollFPS(page, 200, 100)
+
+    console.log(
+      `[${hookVariant}] Scroll 200×100px: ${fps.toFixed(1)} fps, ${elapsed.toFixed(0)}ms, ${renderCount} renders`,
+    )
+
+    // Should maintain at least 30 fps
+    expect(fps).toBeGreaterThan(30)
+  })
+
+  test('rapid small scroll performance (500 frames × 20px)', async ({
+    page,
+    hookVariant,
+  }) => {
+    await page.goto('/perf/')
+    await page.waitForTimeout(500)
+
+    const { fps, elapsed, renderCount } = await collectScrollFPS(page, 500, 20)
+
+    console.log(
+      `[${hookVariant}] Scroll 500×20px: ${fps.toFixed(1)} fps, ${elapsed.toFixed(0)}ms, ${renderCount} renders`,
+    )
+
+    expect(fps).toBeGreaterThan(30)
+  })
+
+  test('scrollToIndex render count', async ({ page, hookVariant }) => {
+    await page.goto('/perf/')
+    await page.waitForTimeout(500)
+
+    const rendersBefore = await getRenderCount(page)
+
+    await page.click('#scroll-to-5000')
+    await page.waitForTimeout(2000) // wait for convergence
+
+    await expect(page.locator('[data-testid="item-5000"]')).toBeVisible()
+
+    const rendersAfter = await getRenderCount(page)
+    const scrollRenders = rendersAfter - rendersBefore
+
+    console.log(
+      `[${hookVariant}] scrollToIndex(5000): ${scrollRenders} renders`,
+    )
+
+    // Experimental should use fewer renders (DOM mutations vs React re-renders)
+    // Just recording — no hard assertion, the value is informational
+  })
+
+  test('scrollToIndex round-trip render count', async ({
+    page,
+    hookVariant,
+  }) => {
+    await page.goto('/perf/')
+    await page.waitForTimeout(500)
+
+    const rendersBefore = await getRenderCount(page)
+
+    // Scroll to end
+    await page.click('#scroll-to-9999')
+    await page.waitForTimeout(2000)
+    await expect(page.locator('[data-testid="item-9999"]')).toBeVisible()
+
+    // Scroll back to start
+    await page.click('#scroll-to-0')
+    await page.waitForTimeout(2000)
+    await expect(page.locator('[data-testid="item-0"]')).toBeVisible()
+
+    const rendersAfter = await getRenderCount(page)
+    const totalRenders = rendersAfter - rendersBefore
+
+    console.log(
+      `[${hookVariant}] scrollToIndex round-trip (9999→0): ${totalRenders} renders`,
+    )
+  })
+})

--- a/packages/react-virtual/e2e/app/test/scroll.spec.ts
+++ b/packages/react-virtual/e2e/app/test/scroll.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 const check = () => {
   const item = document.querySelector('[data-testid="item-1000"]')

--- a/packages/react-virtual/e2e/app/test/smooth-scroll.spec.ts
+++ b/packages/react-virtual/e2e/app/test/smooth-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 test('smooth scrolls to index 1000', async ({ page }) => {
   await page.goto('/smooth-scroll/')

--- a/packages/react-virtual/e2e/app/useHook.ts
+++ b/packages/react-virtual/e2e/app/useHook.ts
@@ -1,0 +1,11 @@
+import {
+  useVirtualizer,
+  useExperimentalDOMVirtualizer,
+} from '@tanstack/react-virtual'
+
+const isExperimental =
+  new URLSearchParams(window.location.search).get('hook') === 'experimental'
+
+export const useHook = (
+  isExperimental ? useExperimentalDOMVirtualizer : useVirtualizer
+) as typeof useVirtualizer

--- a/packages/react-virtual/e2e/app/vite.config.ts
+++ b/packages/react-virtual/e2e/app/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
           'measure-element/index.html',
         ),
         'smooth-scroll': path.resolve(__dirname, 'smooth-scroll/index.html'),
+        perf: path.resolve(__dirname, 'perf/index.html'),
       },
     },
   },

--- a/packages/react-virtual/playwright.config.ts
+++ b/packages/react-virtual/playwright.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
   use: {
     baseURL,
   },
+  projects: [
+    {
+      name: 'useVirtualizer',
+      use: { hookVariant: 'standard' } as any,
+    },
+    {
+      name: 'useExperimentalDOMVirtualizer',
+      use: { hookVariant: 'experimental' } as any,
+    },
+  ],
   webServer: {
     command: `VITE_SERVER_PORT=${PORT} vite build --config e2e/app/vite.config.ts && VITE_SERVER_PORT=${PORT} vite preview --config e2e/app/vite.config.ts --port ${PORT}`,
     url: `${baseURL}/scroll/`,

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -99,3 +99,83 @@ export function useWindowVirtualizer<TItemElement extends Element>(
     ...options,
   })
 }
+
+export function useExperimentalDOMVirtualizer<
+  TScrollElement extends HTMLElement,
+  TItemElement extends HTMLElement,
+>({
+  useFlushSync: shouldFlushSync = true,
+  ...options
+}: PartialKeys<
+  ReactVirtualizerOptions<TScrollElement, TItemElement>,
+  'observeElementRect' | 'observeElementOffset' | 'scrollToFn'
+>): Virtualizer<TScrollElement, TItemElement> {
+  const rerender = React.useReducer(() => ({}), {})[1]
+
+  const prev = React.useRef<{
+    range: { startIndex: number; endIndex: number } | null
+    totalSize: number
+    positions: Map<any, number>
+    isScrolling: boolean
+  }>({ range: null, totalSize: 0, positions: new Map(), isScrolling: false })
+
+  const onChange = (
+    instance: Virtualizer<TScrollElement, TItemElement>,
+    sync: boolean,
+  ) => {
+    const items = instance.getVirtualItems()
+    const totalSize = instance.getTotalSize()
+
+    if (prev.current.totalSize !== totalSize) {
+      const firstItem = items[0]
+      const el = instance.elementsCache.get(firstItem?.key ?? '')?.parentElement
+      if (el) {
+        prev.current.totalSize = totalSize
+        el.style.height = `${totalSize}px`
+      }
+    }
+
+    const positions = new Map<any, number>()
+    items.forEach((item) => {
+      positions.set(item.key, item.start)
+    })
+
+    for (const [key, nextValue] of positions) {
+      const prevValue = prev.current.positions.get(key)
+      if (prevValue !== nextValue) {
+        const el = instance.elementsCache.get(key)
+        if (el) {
+          prev.current.positions.set(key, nextValue)
+          el.style.transform = `translateY(${
+            nextValue - instance.options.scrollMargin
+          }px)`
+        }
+      }
+    }
+
+    if (
+      prev.current.isScrolling !== instance.isScrolling ||
+      prev.current.range?.startIndex !== instance.range?.startIndex ||
+      prev.current.range?.endIndex !== instance.range?.endIndex
+    ) {
+      prev.current.isScrolling = instance.isScrolling
+      prev.current.range = instance.range
+
+      if (shouldFlushSync && sync) {
+        flushSync(rerender)
+      } else {
+        rerender()
+      }
+    }
+  }
+
+  const instance = useVirtualizerBase<TScrollElement, TItemElement>({
+    observeElementRect: observeElementRect,
+    observeElementOffset: observeElementOffset,
+    scrollToFn: elementScroll,
+    ...options,
+  })
+  instance.options.onChange = onChange
+
+  return instance
+}


### PR DESCRIPTION
## 🎯 Changes

### Performance Comparison: `useVirtualizer` vs `useExperimentalDOMVirtualizer`

All 32 tests passed (34.7s).

| Metric | `useVirtualizer` | `useExperimentalVirtualizer` | Difference |
|---|---|---|---|
| **Initial render** | 30.1ms, 3 renders | 26.3ms, 3 renders | ~13% faster |
| **Scroll 200×100px** | 60.0 fps, **407 renders** | 59.9 fps, **215 renders** | **47% fewer renders** |
| **Scroll 500×20px** | 60.1 fps, **410 renders** | 60.1 fps, **264 renders** | **36% fewer renders** |
| **scrollToIndex(5000)** | 4 renders | 5 renders | similar |
| **Round-trip (9999→0)** | 6 renders | 6 renders | identical |

### Key Takeaways

- The experimental hook cuts React render count **nearly in half** during continuous scrolling while maintaining the same **60fps**.
- Both hooks achieve identical frame rates — the render savings translate to **lower CPU usage** and better battery life.
- The difference will be more pronounced on slower devices or with heavier item components.

### How it works

`useExperimentalVirtualizer` bypasses React re-renders for item positioning by directly mutating DOM styles (`transform`, `height`) during scroll. It only triggers a React re-render when the **visible range** or **`isScrolling` state** changes, which happens far less frequently than per-frame position updates.

### Test setup

- **10,000 items** with random heights (25–100px)
- Scroll container: 400px height, `contain: strict`, `overflowAnchor: none`
- Playwright + Chromium, production build

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
