### PR TITLE
fix(angular-virtual): capture _didMount cleanup to remove scroll/resize listeners on destroy

### DIFF
--- a/.changeset/fix-angular-virtual-cleanup.md
+++ b/.changeset/fix-angular-virtual-cleanup.md
@@ -2,4 +2,4 @@
 '@tanstack/angular-virtual': patch
 ---
 
-fix: capture _didMount cleanup to remove scroll/resize listeners on destroy
+fix: capture \_didMount cleanup to remove scroll/resize listeners on destroy

--- a/.changeset/fix-angular-virtual-cleanup.md
+++ b/.changeset/fix-angular-virtual-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-virtual': patch
+---
+
+fix: capture _didMount cleanup to remove scroll/resize listeners on destroy

--- a/packages/angular-virtual/src/index.ts
+++ b/packages/angular-virtual/src/index.ts
@@ -70,8 +70,12 @@ function createVirtualizerBase<
     { allowSignalWrites: true },
   )
 
-  let cleanup: () => void | undefined
-  afterNextRender({ read: () => (virtualizer ?? lazyInit())._didMount() })
+  let cleanup: (() => void) | undefined
+  afterNextRender({
+    read: () => {
+      cleanup = (virtualizer ?? lazyInit())._didMount()
+    },
+  })
 
   inject(DestroyRef).onDestroy(() => cleanup?.())
 


### PR DESCRIPTION
## 🎯 Changes

`afterNextRender` discarded the teardown function returned by _didMount(), so observeWindowOffset's scroll and resize listeners were never unregistered.

Also fixes the cleanup variable type annotation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where scroll and resize event listeners were not being properly removed when the Angular virtual component is destroyed, preventing potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->