### PR TITLE
fix(virtual-core): prevent scroll jumps when scrolling backward over cached items

### DIFF
--- a/packages/react-virtual/e2e/app/backward-scroll/index.html
+++ b/packages/react-virtual/e2e/app/backward-scroll/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Backward scroll</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/react-virtual/e2e/app/backward-scroll/main.tsx
+++ b/packages/react-virtual/e2e/app/backward-scroll/main.tsx
@@ -83,4 +83,3 @@ const App = () => {
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
-

--- a/packages/react-virtual/e2e/app/backward-scroll/main.tsx
+++ b/packages/react-virtual/e2e/app/backward-scroll/main.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+const COUNT = 500
+
+// Rows mount at one height and then grow shortly after (simulates an image
+// or async content loading and pushing the row taller). This is exactly the
+// scenario where backward-scroll jumps happen: a row already in the measured
+// cache at size X changes to size Y after a tiny delay, the ResizeObserver
+// fires while the user is still scrolling up, and resizeItem triggers a
+// scroll adjustment that visually jumps the page.
+const Row: React.FC<{ index: number }> = ({ index }) => {
+  const [grown, setGrown] = React.useState(false)
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setGrown(true), 150)
+    return () => clearTimeout(t)
+  }, [])
+
+  const extra = grown ? 60 + (index % 5) * 4 : 0
+
+  return (
+    <div
+      style={{
+        padding: 8,
+        height: 40 + extra,
+        boxSizing: 'border-box',
+        borderBottom: '1px solid #ccc',
+      }}
+    >
+      Row {index}
+    </div>
+  )
+}
+
+const App = () => {
+  const parentRef = React.useRef<HTMLDivElement>(null)
+
+  const rowVirtualizer = useVirtualizer({
+    count: COUNT,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 50,
+    overscan: 5,
+  })
+
+  return (
+    <div>
+      <div
+        ref={parentRef}
+        id="scroll-container"
+        data-testid="scroll-container"
+        style={{ height: 400, width: 400, overflow: 'auto' }}
+      >
+        <div
+          style={{
+            height: rowVirtualizer.getTotalSize(),
+            position: 'relative',
+            width: '100%',
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().map((v) => (
+            <div
+              key={v.key}
+              data-testid={`item-${v.index}`}
+              data-index={v.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${v.start}px)`,
+              }}
+            >
+              <Row index={v.index} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
+

--- a/packages/react-virtual/e2e/app/test/backward-scroll.spec.ts
+++ b/packages/react-virtual/e2e/app/test/backward-scroll.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+
+// Regression test for the "jump while scrolling backward" bug.
+//
+// Repro: jump into the middle of a list with dynamically measured items,
+// then scroll upward with the wheel. Previously the ResizeObserver would
+// re-fire for items that were already measured, triggering scroll
+// adjustments that caused visible jumps. The fix skips re-measuring
+// cached items during backward user scroll.
+test('does not jump when scrolling backward from the middle of a dynamic list', async ({
+  page,
+}) => {
+  await page.goto('/backward-scroll/')
+
+  const container = page.locator('[data-testid="scroll-container"]')
+  await expect(container).toBeVisible()
+
+  // Jump into the middle of the list
+  await container.evaluate((el) => {
+    ;(el as HTMLElement).scrollTop = 8000
+  })
+
+  // Let the browser lay out and measure the freshly rendered items
+  await page.waitForTimeout(200)
+
+  const startTop = await container.evaluate(
+    (el) => (el as HTMLElement).scrollTop,
+  )
+  expect(startTop).toBeGreaterThan(7000)
+
+  // Scroll upward with the wheel while sampling scrollTop. If a scroll
+  // adjustment happens mid-scroll, scrollTop will jump *upward* between
+  // two consecutive samples even though we're scrolling up ourselves.
+  // We detect that by checking that scrollTop never increases between
+  // two consecutive samples during the backward scroll.
+  const samples: Array<number> = []
+  samples.push(startTop)
+
+  for (let i = 0; i < 20; i++) {
+    await container.hover()
+    await page.mouse.wheel(0, -120)
+    // Yield to the browser so RO/scroll events can flush
+    await page.waitForTimeout(40)
+    const top = await container.evaluate(
+      (el) => (el as HTMLElement).scrollTop,
+    )
+    samples.push(top)
+  }
+
+  // While the user is wheel-scrolling up, scrollTop must be monotonically
+  // non-increasing. Any increase > a small tolerance means a jump occurred.
+  const TOLERANCE = 2
+  for (let i = 1; i < samples.length; i++) {
+    const prev = samples[i - 1]!
+    const curr = samples[i]!
+    expect(
+      curr,
+      `Jump detected at sample ${i}: ${prev} -> ${curr}`,
+    ).toBeLessThanOrEqual(prev + TOLERANCE)
+  }
+
+  // After scrolling stops, the layout should settle: items rendered
+  // contiguously with no gaps / overlaps.
+  await page.waitForTimeout(400)
+
+  const rects = await page.evaluate(() => {
+    const nodes = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid^="item-"]'),
+    )
+    return nodes
+      .map((n) => ({
+        index: Number(n.dataset.index),
+        top: n.getBoundingClientRect().top,
+        bottom: n.getBoundingClientRect().bottom,
+      }))
+      .sort((a, b) => a.index - b.index)
+  })
+
+  for (let i = 1; i < rects.length; i++) {
+    const prev = rects[i - 1]!
+    const curr = rects[i]!
+    // Items are rendered back-to-back: curr.top should equal prev.bottom
+    expect(Math.abs(curr.top - prev.bottom)).toBeLessThanOrEqual(1)
+  }
+})

--- a/packages/react-virtual/e2e/app/test/backward-scroll.spec.ts
+++ b/packages/react-virtual/e2e/app/test/backward-scroll.spec.ts
@@ -41,9 +41,7 @@ test('does not jump when scrolling backward from the middle of a dynamic list', 
     await page.mouse.wheel(0, -120)
     // Yield to the browser so RO/scroll events can flush
     await page.waitForTimeout(40)
-    const top = await container.evaluate(
-      (el) => (el as HTMLElement).scrollTop,
-    )
+    const top = await container.evaluate((el) => (el as HTMLElement).scrollTop)
     samples.push(top)
   }
 

--- a/packages/react-virtual/e2e/app/vite.config.ts
+++ b/packages/react-virtual/e2e/app/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         ),
         'smooth-scroll': path.resolve(__dirname, 'smooth-scroll/index.html'),
         'stale-index': path.resolve(__dirname, 'stale-index/index.html'),
+        'backward-scroll': path.resolve(
+          __dirname,
+          'backward-scroll/index.html',
+        ),
       },
     },
   },

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -384,6 +384,10 @@ export class Virtualizer<
   private prevLanes: number | undefined = undefined
   private lanesChangedFlag = false
   private lanesSettling = false
+  // Set while we are skipping RO-driven re-measurements during backward
+  // user scrolling. When scrolling stops we flush by re-measuring all
+  // currently rendered items so the cache catches up with the DOM.
+  private skippedBackwardMeasurements = false
   scrollRect: Rect | null = null
   scrollOffset: number | null = null
   scrollDirection: ScrollDirection | null = null
@@ -421,6 +425,22 @@ export class Virtualizer<
             }
 
             if (this.shouldMeasureDuringScroll(index)) {
+              // During user-initiated backward scrolling, skip re-measuring
+              // items that already have a cached size to avoid scroll
+              // adjustments causing visible jumps. When scrolling stops we
+              // re-measure all rendered items so the cache catches up.
+              if (
+                this.isScrolling &&
+                this.scrollDirection === 'backward' &&
+                !this.scrollState
+              ) {
+                const item = this.measurementsCache[index]
+                if (item && this.itemSizeCache.has(item.key)) {
+                  this.skippedBackwardMeasurements = true
+                  return
+                }
+              }
+
               this.resizeItem(
                 index,
                 this.options.measureElement(node, entry, this),
@@ -448,6 +468,17 @@ export class Virtualizer<
 
   constructor(opts: VirtualizerOptions<TScrollElement, TItemElement>) {
     this.setOptions(opts)
+  }
+
+  private flushPendingBackwardScrollMeasures = () => {
+    if (!this.skippedBackwardMeasurements) return
+    this.skippedBackwardMeasurements = false
+    this.elementsCache.forEach((node) => {
+      if (!node.isConnected) return
+      const index = this.indexFromElement(node)
+      if (index < 0) return
+      this.resizeItem(index, this.options.measureElement(node, undefined, this))
+    })
   }
 
   setOptions = (opts: VirtualizerOptions<TScrollElement, TItemElement>) => {
@@ -523,6 +554,7 @@ export class Virtualizer<
     this.scrollState = null
     this.scrollElement = null
     this.targetWindow = null
+    this.skippedBackwardMeasurements = false
   }
 
   _didMount = () => {
@@ -572,7 +604,12 @@ export class Virtualizer<
               : 'backward'
             : null
           this.scrollOffset = offset
+          const wasScrolling = this.isScrolling
           this.isScrolling = isScrolling
+
+          if (wasScrolling && !isScrolling) {
+            this.flushPendingBackwardScrollMeasures()
+          }
 
           if (this.scrollState) {
             this.scheduleScrollReconcile()


### PR DESCRIPTION
## 🎯 Changes

During user-initiated backward scrolling, ResizeObserver entries for items that are already in the size cache triggered resizeItem -> scroll adjustments, causing visible jumps (most noticeable when items change size shortly after mounting, e.g. async content).

Skip re-measuring cached items while scrolling backward and flush by re-measuring all currently rendered items once scrolling stops, so the cache still catches up with the DOM.

Adds a Playwright regression test that jumps to the middle of a dynamic list and asserts scrollTop is monotonically non-increasing while wheel-scrolling up.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved backward scrolling performance and layout accuracy when items have dynamic sizes.

* **Tests**
  * Added end-to-end test coverage for backward scrolling scenarios with dynamically sized items to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->