### PR TITLE
chore: enforce pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "url": "git+https://github.com/TanStack/virtual.git"
   },
   "packageManager": "pnpm@11.1.0",
+  "engines": {
+    "pnpm": ">=11.0.0"
+  },
   "type": "module",
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",


### PR DESCRIPTION
Adds `engines.pnpm >=11.9.0` to TanStack/virtual.

| Scenario | Result |
|---|---|
| `pnpm@11+ install` | Allowed |
| `pnpm@11+ run ...` | Allowed |
| `pnpm@9 install` | Blocked by `engines.pnpm` |
| `pnpm@9 run ...` | Blocked by `engines.pnpm` |
| `pnpm@10 install` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 run ...` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 install` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@10 run ...` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@9/10 list` | Not blocked |
| `pnpm@9/10 exec ...` | Not blocked |

| Field | What It Does |
|---|---|
| `packageManager` | Helps tools/newer pnpm select or hand off to the declared pnpm version |
| `engines.pnpm: ">=11.0.0"` | Fails important project workflows when an older pnpm is actually executing them |
| `engines.pnpm` | Does not intercept every pnpm subcommand |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pnpm version requirement to `>=11.9.0`, aligning with the existing `pnpm@11.9.0` package manager setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->