### PR TITLE
fix(virtual-core): eagerly adjust scrollOffset on prepend to prevent jump

### DIFF
--- a/.changeset/eager-scroll-anchor.md
+++ b/.changeset/eager-scroll-anchor.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Eagerly adjust scrollOffset on prepend to prevent one-frame jump with anchorTo: 'end'
+
+When items are prepended with `anchorTo: 'end'` and dynamic sizes, the virtualizer would compute the wrong visible range for one frame (using stale estimate-based positions) and then correct in the next frame via `_willUpdate`, producing a visible jump. This fix eagerly adjusts `scrollOffset` in `setOptions` during the render pass so `calculateRange`/`getVirtualItems` return the correct items immediately.

--- a/examples/react/chat/src/main.tsx
+++ b/examples/react/chat/src/main.tsx
@@ -43,11 +43,15 @@ function App() {
     count: messages.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 74,
-    getItemKey: (index) => messages[index]!.id,
+    getItemKey: React.useCallback(
+      (index: number) => messages[index]!.id,
+      [messages],
+    ),
     anchorTo: 'end',
     followOnAppend: true,
     scrollEndThreshold: 80,
     overscan: 6,
+    directDomUpdates: true,
   })
 
   const virtualItems = virtualizer.getVirtualItems()
@@ -180,8 +184,8 @@ function App() {
           }}
         >
           <div
+            ref={virtualizer.containerRef}
             style={{
-              height: virtualizer.getTotalSize(),
               position: 'relative',
               width: '100%',
             }}
@@ -199,7 +203,6 @@ function App() {
                     position: 'absolute',
                     top: 0,
                     left: 0,
-                    transform: `translateY(${virtualItem.start}px)`,
                     width: '100%',
                   }}
                 >

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -365,6 +365,7 @@ type PendingScrollAnchor = [
   key: Key | null,
   offset: number,
   followOnAppend: ScrollBehavior | null,
+  anchorDelta: number,
 ]
 
 export class Virtualizer<
@@ -535,6 +536,7 @@ export class Virtualizer<
       | undefined
     let anchor: [Key, number] | null = null
     let followOnAppend: ScrollBehavior | null = null
+    let edgeKeysChanged = false
 
     if (
       prevOptions !== undefined &&
@@ -564,6 +566,7 @@ export class Virtualizer<
             merged.getItemKey(nextCount - 1) !== prevLastKey))
 
       if (didEdgeKeysChange) {
+        edgeKeysChanged = true
         const item =
           prevCount > 0
             ? (this.getVirtualItemForOffset(this.getScrollOffset()) ??
@@ -592,11 +595,51 @@ export class Virtualizer<
 
     this.options = merged
 
-    if (anchor || followOnAppend) {
+    // When edge keys changed (prepend, trim, reorder, etc.) the key→index
+    // mapping has shifted. Force a full measurement rebuild so the anchor
+    // resolution below reads positions from the new layout, not the stale
+    // memoised cache. Without this, a stable `getItemKey` reference +
+    // unchanged `count` would let getMeasurements() return the old layout.
+    if (edgeKeysChanged) {
+      this.pendingMin = 0
+      this.itemSizeCacheVersion++
+    }
+
+    // Eagerly adjust scrollOffset so the virtualizer computes the correct
+    // visible range during the current render pass — before _willUpdate
+    // syncs the DOM scroll position in a layout effect. Without this,
+    // the virtualizer would render the wrong items for one frame (the
+    // estimate-based positions are stale) and then correct in the next
+    // frame, producing a visible "jump" on prepend with dynamic sizes.
+    let anchorResolved = false
+    let anchorDelta = 0
+    if (anchor && this.scrollOffset !== null) {
+      const [anchorKey, anchorOffset] = anchor
+      const newMeasurements = this.getMeasurements()
+      const { count, getItemKey } = this.options
+      let idx = 0
+      while (idx < count && getItemKey(idx) !== anchorKey) {
+        idx++
+      }
+      if (idx < count) {
+        const anchorItem = newMeasurements[idx]
+        if (anchorItem) {
+          const newOffset = anchorItem.start + anchorOffset
+          if (newOffset !== this.scrollOffset) {
+            anchorDelta = newOffset - this.scrollOffset
+            this.scrollOffset = newOffset
+            anchorResolved = true
+          }
+        }
+      }
+    }
+
+    if (anchorResolved || followOnAppend) {
       this.pendingScrollAnchor = [
-        anchor?.[0] ?? null,
-        anchor?.[1] ?? 0,
+        anchorResolved ? anchor![0] : null,
+        anchorResolved ? anchor![1] : 0,
         followOnAppend,
+        anchorDelta,
       ]
     }
   }
@@ -798,22 +841,30 @@ export class Virtualizer<
     this.pendingScrollAnchor = null
 
     if (anchor && this.scrollElement && this.options.enabled) {
-      const [key, offset, followOnAppend] = anchor
+      const [key, _offset, followOnAppend, anchorDelta] = anchor
 
-      if (key !== null) {
-        const { count, getItemKey } = this.options
-        let index = 0
-        while (index < count && getItemKey(index) !== key) {
-          index++
-        }
-
-        const item = index < count ? this.getMeasurements()[index] : undefined
-        if (item) {
-          const delta = item.start + offset - this.getScrollOffset()
-
-          if (!approxEqual(delta, 0)) {
-            this.applyScrollAdjustment(delta)
+      if (key !== null && !followOnAppend) {
+        // scrollOffset was eagerly adjusted in setOptions so the
+        // virtualizer already computed the correct range during render.
+        // Now sync the browser's actual scroll position to match.
+        // Skip when followOnAppend is set — scrollToEnd will handle it.
+        //
+        // On iOS WebKit, writing scrollTop during touch/momentum cancels
+        // the in-flight scroll. Defer the DOM sync the same way
+        // applyScrollAdjustment does — accumulate the delta and let
+        // _flushIosDeferredIfReady handle it once the scroll settles.
+        if (
+          isIOSWebKit() &&
+          (this.isScrolling || this._iosTouching || this._iosJustTouchEnded)
+        ) {
+          if (anchorDelta !== 0) {
+            this._iosDeferredAdjustment += anchorDelta
           }
+        } else {
+          this._scrollToOffset(this.getScrollOffset(), {
+            adjustments: undefined,
+            behavior: undefined,
+          })
         }
       }
 

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -2275,8 +2275,8 @@ test('anchorTo:end keeps visible content stable when older items are prepended',
 
   expect(scrollToFn).toHaveBeenCalledTimes(1)
   const [offset, options] = scrollToFn.mock.calls[0]!
-  expect(offset).toBe(100)
-  expect(options.adjustments).toBe(100)
+  expect(offset).toBe(200)
+  expect(options.adjustments).toBeUndefined()
 })
 
 test('anchorTo:end does not yank a scrolled-up user when items append', () => {


### PR DESCRIPTION
When items are prepended with anchorTo: 'end' and dynamic sizes, the virtualizer would compute the wrong visible range for one frame (using stale estimate-based positions) and then correct in the next frame via _willUpdate, producing a visible "jump".

Fix by eagerly adjusting scrollOffset in setOptions during the render pass so calculateRange/getVirtualItems return the correct items immediately. _willUpdate then only syncs the browser's actual scroll position to match.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a visible one-frame jump when items are prepended/appended by eagerly reconciling scroll offset so visible items render consistently.
  * Reduced deferred platform-specific adjustments by synchronizing the browser scroll position immediately when possible, improving render stability (iOS momentum handling deferred adjustments until safe).
* **Tests**
  * Updated virtualization tests to reflect the new scroll reconciliation behavior and expected offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->