### PR TITLE
feat(react-virtual): add directDomUpdates for re-render-free scroll positioning

### DIFF
--- a/.changeset/direct-dom-updates.md
+++ b/.changeset/direct-dom-updates.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-virtual': minor
+---
+
+Add opt-in direct DOM updates for scroll positioning with `directDomUpdates`, `directDomUpdatesMode`, and `containerRef`.

--- a/examples/react/dynamic/src/main.tsx
+++ b/examples/react/dynamic/src/main.tsx
@@ -38,7 +38,7 @@ function RowVirtualizerDynamic() {
           virtualizer.scrollToIndex(0)
         }}
       >
-        scroll to the top2
+        scroll to the top
       </button>
       <span style={{ padding: '0 4px' }} />
       <button

--- a/examples/react/dynamic/src/main.tsx
+++ b/examples/react/dynamic/src/main.tsx
@@ -24,13 +24,12 @@ function RowVirtualizerDynamic() {
     getScrollElement: () => parentRef.current,
     estimateSize: () => 45,
     enabled,
+    directDomUpdates: true,
   })
 
   React.useEffect(() => {
     virtualizer.scrollToIndex(count - 1, { align: 'end' })
   }, [])
-
-  const items = virtualizer.getVirtualItems()
 
   return (
     <div>
@@ -39,7 +38,7 @@ function RowVirtualizerDynamic() {
           virtualizer.scrollToIndex(0)
         }}
       >
-        scroll to the top
+        scroll to the top2
       </button>
       <span style={{ padding: '0 4px' }} />
       <button
@@ -78,37 +77,32 @@ function RowVirtualizerDynamic() {
         }}
       >
         <div
+          ref={virtualizer.containerRef}
           style={{
-            height: virtualizer.getTotalSize(),
             width: '100%',
             position: 'relative',
           }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${items[0]?.start ?? 0}px)`,
-            }}
-          >
-            {items.map((virtualRow) => (
-              <div
-                key={virtualRow.key}
-                data-index={virtualRow.index}
-                ref={virtualizer.measureElement}
-                className={
-                  virtualRow.index % 2 ? 'ListItemOdd' : 'ListItemEven'
-                }
-              >
-                <div style={{ padding: '10px 0' }}>
-                  <div>Row {virtualRow.index}</div>
-                  <div>{sentences[virtualRow.index]}</div>
-                </div>
+          {virtualizer.getVirtualItems().map((v) => (
+            <div
+              key={v.key}
+              data-testid={`item-${v.index}`}
+              ref={virtualizer.measureElement}
+              className={v.index % 2 ? 'ListItemOdd' : 'ListItemEven'}
+              data-index={v.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+              }}
+            >
+              <div style={{ padding: '10px 0' }}>
+                <div>Row {v.index}</div>
+                <div>{sentences[v.index]}</div>
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/packages/react-virtual/e2e/app/direct-dom-updates/index.html
+++ b/packages/react-virtual/e2e/app/direct-dom-updates/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/react-virtual/e2e/app/direct-dom-updates/main.tsx
+++ b/packages/react-virtual/e2e/app/direct-dom-updates/main.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+const ITEM_SIZE = 40
+const COUNT = 1000
+
+const App = () => {
+  const parentRef = React.useRef<HTMLDivElement>(null)
+
+  const params = new URLSearchParams(window.location.search)
+  const mode = (params.get('mode') ?? 'position') as 'position' | 'transform'
+
+  const renderCount = React.useRef(0)
+  renderCount.current += 1
+
+  const rowVirtualizer = useVirtualizer({
+    count: COUNT,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ITEM_SIZE,
+    overscan: 2,
+    directDomUpdates: true,
+    directDomUpdatesMode: mode,
+  })
+
+  return (
+    <div>
+      <div data-testid="render-count">{renderCount.current}</div>
+      <div data-testid="mode">{mode}</div>
+      <button
+        id="scroll-to-500"
+        onClick={() => rowVirtualizer.scrollToIndex(500)}
+      >
+        Scroll to 500
+      </button>
+
+      <div
+        ref={parentRef}
+        id="scroll-container"
+        style={{ height: 400, overflow: 'auto' }}
+      >
+        <div
+          ref={rowVirtualizer.containerRef}
+          id="inner"
+          style={{ position: 'relative', width: '100%' }}
+        >
+          {rowVirtualizer.getVirtualItems().map((v) => (
+            <div
+              key={v.key}
+              data-testid={`item-${v.index}`}
+              ref={rowVirtualizer.measureElement}
+              data-index={v.index}
+              style={{
+                position: 'absolute',
+                left: 0,
+                width: '100%',
+                height: ITEM_SIZE,
+                ...(mode === 'transform' ? { top: 0 } : null),
+              }}
+            >
+              Row {v.index}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />)

--- a/packages/react-virtual/e2e/app/direct-dom-updates/main.tsx
+++ b/packages/react-virtual/e2e/app/direct-dom-updates/main.tsx
@@ -9,7 +9,7 @@ const App = () => {
   const parentRef = React.useRef<HTMLDivElement>(null)
 
   const params = new URLSearchParams(window.location.search)
-  const mode = (params.get('mode') ?? 'position') as 'position' | 'transform'
+  const mode = (params.get('mode') ?? 'transform') as 'position' | 'transform'
 
   const renderCount = React.useRef(0)
   renderCount.current += 1

--- a/packages/react-virtual/e2e/app/test/direct-dom-updates.spec.ts
+++ b/packages/react-virtual/e2e/app/test/direct-dom-updates.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test'
+
+const ITEM_SIZE = 40
+const COUNT = 1000
+
+for (const mode of ['position', 'transform'] as const) {
+  test.describe(`directDomUpdates mode=${mode}`, () => {
+    test('sets container size and positions items via direct DOM updates', async ({
+      page,
+    }) => {
+      await page.goto(`/direct-dom-updates/?mode=${mode}`)
+
+      await expect(page.locator('[data-testid="mode"]')).toHaveText(mode)
+
+      // Container height is written directly by containerRef, NOT from JSX style.
+      const inner = page.locator('#inner')
+      await expect(inner).toHaveAttribute(
+        'style',
+        new RegExp(`height:\\s*${COUNT * ITEM_SIZE}px`),
+      )
+
+      // First item is at top 0 (position) or translate3d(0, 0, 0) (transform).
+      const first = page.locator('[data-testid="item-0"]')
+      await expect(first).toBeVisible()
+      if (mode === 'position') {
+        await expect(first).toHaveAttribute('style', /top:\s*0px/)
+      } else {
+        await expect(first).toHaveAttribute(
+          'style',
+          /translate3d\(0px,\s*0px,\s*0px\)/,
+        )
+      }
+    })
+
+    test('scrolling moves items via direct DOM without per-pixel React re-renders', async ({
+      page,
+    }) => {
+      await page.goto(`/direct-dom-updates/?mode=${mode}`)
+
+      const initialRenders = Number(
+        await page.locator('[data-testid="render-count"]').textContent(),
+      )
+
+      // Scroll by exactly one item — does NOT change the visible range
+      // (overscan absorbs it), so React should not re-render.
+      await page.locator('#scroll-container').evaluate((el, by) => {
+        el.scrollTop = by
+      }, ITEM_SIZE)
+
+      // Give onChange a tick.
+      await page.waitForTimeout(50)
+
+      const item1 = page.locator('[data-testid="item-1"]')
+      const styleAttr = (await item1.getAttribute('style')) ?? ''
+
+      if (mode === 'position') {
+        expect(styleAttr).toMatch(/top:\s*40px/)
+      } else {
+        expect(styleAttr).toMatch(/translate3d\(0px,\s*40px,\s*0px\)/)
+      }
+
+      const renderAfterSmallScroll = Number(
+        await page.locator('[data-testid="render-count"]').textContent(),
+      )
+      // Allow at most 1 extra render (isScrolling flip), zero for the offset itself.
+      expect(renderAfterSmallScroll - initialRenders).toBeLessThanOrEqual(2)
+    })
+
+    test('large scroll triggers a re-render and items still position correctly', async ({
+      page,
+    }) => {
+      await page.goto(`/direct-dom-updates/?mode=${mode}`)
+
+      const before = Number(
+        await page.locator('[data-testid="render-count"]').textContent(),
+      )
+
+      await page.click('#scroll-to-500')
+
+      // Wait for the new range to render.
+      await expect(page.locator('[data-testid="item-500"]')).toBeVisible()
+
+      const after = Number(
+        await page.locator('[data-testid="render-count"]').textContent(),
+      )
+      expect(after).toBeGreaterThan(before)
+
+      const item500 = page.locator('[data-testid="item-500"]')
+      const style = (await item500.getAttribute('style')) ?? ''
+      if (mode === 'position') {
+        expect(style).toMatch(/top:\s*20000px/)
+      } else {
+        expect(style).toMatch(/translate3d\(0px,\s*20000px,\s*0px\)/)
+      }
+    })
+  })
+}

--- a/packages/react-virtual/e2e/app/test/direct-dom-updates.spec.ts
+++ b/packages/react-virtual/e2e/app/test/direct-dom-updates.spec.ts
@@ -47,17 +47,13 @@ for (const mode of ['position', 'transform'] as const) {
         el.scrollTop = by
       }, ITEM_SIZE)
 
-      // Give onChange a tick.
-      await page.waitForTimeout(50)
-
       const item1 = page.locator('[data-testid="item-1"]')
-      const styleAttr = (await item1.getAttribute('style')) ?? ''
-
-      if (mode === 'position') {
-        expect(styleAttr).toMatch(/top:\s*40px/)
-      } else {
-        expect(styleAttr).toMatch(/translate3d\(0px,\s*40px,\s*0px\)/)
-      }
+      await expect(item1).toHaveAttribute(
+        'style',
+        mode === 'position'
+          ? /top:\s*40px/
+          : /translate3d\(0px,\s*40px,\s*0px\)/,
+      )
 
       const renderAfterSmallScroll = Number(
         await page.locator('[data-testid="render-count"]').textContent(),

--- a/packages/react-virtual/e2e/app/vite.config.ts
+++ b/packages/react-virtual/e2e/app/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         ),
         'smooth-scroll': path.resolve(__dirname, 'smooth-scroll/index.html'),
         'stale-index': path.resolve(__dirname, 'stale-index/index.html'),
+        'direct-dom-updates': path.resolve(
+          __dirname,
+          'direct-dom-updates/index.html',
+        ),
       },
     },
   },

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -40,9 +40,11 @@ export type ReactVirtualizerOptions<
    * or `isScrolling` changes.
    *
    * Requirements when enabled:
-   * - Item elements must be `position: absolute` and must NOT set `top` /
-   *   `left` (or `transform: translate*`) in their style — the virtualizer
-   *   owns the main axis.
+   * - Item elements must be `position: absolute`; in `'transform'` mode they
+   *   must also be anchored with `top: 0` / `left: 0`.
+   * - Item elements must NOT set the main-axis position in their style — the
+   *   virtualizer owns `top` / `left` in `'position'` mode and `transform` in
+   *   `'transform'` mode.
    * - The inner sized container must receive `virtualizer.containerRef` and
    *   must NOT set `height` / `width` in its style.
    * - For multi-lane layouts (grids / masonry), the cross-axis position
@@ -56,12 +58,13 @@ export type ReactVirtualizerOptions<
   directDomUpdates?: boolean
   /**
    * How `directDomUpdates` positions item elements.
-   * - `'position'` (default): writes `top` / `left`. Item elements must be
+   * - `'transform'` (default): writes `transform: translate3d(...)`.
+   *   Promotes items to their own compositor layer — usually smoother on long
+   *   lists, but creates a stacking context and can interfere with
+   *   `position: fixed` descendants. Item elements must still be anchored with
+   *   `position: absolute`, `top: 0`, and `left: 0`.
+   * - `'position'`: writes `top` / `left`. Item elements must be
    *   `position: absolute`.
-   * - `'transform'`: writes `transform: translate3d(...)`. Promotes items
-   *   to their own compositor layer — usually smoother on long lists, but
-   *   creates a stacking context and can interfere with `position: fixed`
-   *   descendants.
    */
   directDomUpdatesMode?: 'position' | 'transform'
 }
@@ -179,21 +182,20 @@ function useVirtualizerBase<
   }
 
   const [instance] = React.useState(() => {
-    const v = new Virtualizer<TScrollElement, TItemElement>(
-      resolvedOptions,
-    ) as ReactVirtualizer<TScrollElement, TItemElement>
-    v.containerRef = (node: HTMLElement | null) => {
-      const state = directRef.current
-      state.container = node
-      state.lastSize = null
-      if (node && state.enabled) {
-        const total = v.getTotalSize()
-        state.lastSize = total
-        const axis = v.options.horizontal ? 'width' : 'height'
-        node.style[axis] = `${total}px`
-      }
-    }
-    return v
+    const v = new Virtualizer<TScrollElement, TItemElement>(resolvedOptions)
+    return Object.assign(v, {
+      containerRef: (node: HTMLElement | null) => {
+        const state = directRef.current
+        state.container = node
+        state.lastSize = null
+        if (node && state.enabled) {
+          const total = v.getTotalSize()
+          state.lastSize = total
+          const axis = v.options.horizontal ? 'width' : 'height'
+          node.style[axis] = `${total}px`
+        }
+      },
+    })
   })
 
   instance.setOptions(resolvedOptions)

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -16,11 +16,54 @@ export * from '@tanstack/virtual-core'
 const useIsomorphicLayoutEffect =
   typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
+export type ReactVirtualizer<
+  TScrollElement extends Element | Window,
+  TItemElement extends Element,
+> = Virtualizer<TScrollElement, TItemElement> & {
+  /**
+   * Ref callback for the inner sized container element. Only meaningful when
+   * `directDomUpdates: true` — the virtualizer writes the container's
+   * main-axis size (`height` or `width`) directly to skip React re-renders.
+   */
+  containerRef: (node: HTMLElement | null) => void
+}
+
 export type ReactVirtualizerOptions<
   TScrollElement extends Element | Window,
   TItemElement extends Element,
 > = VirtualizerOptions<TScrollElement, TItemElement> & {
   useFlushSync?: boolean
+  /**
+   * Skip React re-renders for scroll-only updates. The virtualizer writes
+   * item positions (`top`/`left`) and the container size (`height`/`width`)
+   * directly to the DOM, and only re-renders when the visible index range
+   * or `isScrolling` changes.
+   *
+   * Requirements when enabled:
+   * - Item elements must be `position: absolute` and must NOT set `top` /
+   *   `left` (or `transform: translate*`) in their style — the virtualizer
+   *   owns the main axis.
+   * - The inner sized container must receive `virtualizer.containerRef` and
+   *   must NOT set `height` / `width` in its style.
+   * - For multi-lane layouts (grids / masonry), the cross-axis position
+   *   (e.g. `left: ${(item.lane * 100) / lanes}%`) is stable per item and
+   *   must still be set in your JSX — only the main axis is automated.
+   *
+   * This flag is intended to be set once at mount. Toggling it (or
+   *  `directDomUpdatesMode`) at runtime can leave stale inline styles on
+   *  items and the container.
+   */
+  directDomUpdates?: boolean
+  /**
+   * How `directDomUpdates` positions item elements.
+   * - `'position'` (default): writes `top` / `left`. Item elements must be
+   *   `position: absolute`.
+   * - `'transform'`: writes `transform: translate3d(...)`. Promotes items
+   *   to their own compositor layer — usually smoother on long lists, but
+   *   creates a stacking context and can interfere with `position: fixed`
+   *   descendants.
+   */
+  directDomUpdatesMode?: 'position' | 'transform'
 }
 
 function useVirtualizerBase<
@@ -28,28 +71,130 @@ function useVirtualizerBase<
   TItemElement extends Element,
 >({
   useFlushSync = true,
+  directDomUpdates = false,
+  directDomUpdatesMode = 'transform',
   ...options
-}: ReactVirtualizerOptions<TScrollElement, TItemElement>): Virtualizer<
+}: ReactVirtualizerOptions<TScrollElement, TItemElement>): ReactVirtualizer<
   TScrollElement,
   TItemElement
 > {
   const rerender = React.useReducer((x: number) => x + 1, 0)[1]
 
+  // Mutable across renders so the onChange closure captured by setOptions
+  // always reads the latest values without us having to re-create it.
+  const directRef = React.useRef({
+    enabled: directDomUpdates,
+    mode: directDomUpdatesMode,
+    container: null as HTMLElement | null,
+    lastSize: null as number | null,
+    // Keyed by the element itself so a remounted node (same key, new DOM
+    // node — e.g. when `enabled` is toggled off then on) is treated as fresh
+    // and gets its style written.
+    lastPositions: new WeakMap<HTMLElement, number>(),
+    prevRange: null as {
+      startIndex: number
+      endIndex: number
+      isScrolling: boolean
+    } | null,
+  })
+  directRef.current.enabled = directDomUpdates
+  directRef.current.mode = directDomUpdatesMode
+
+  // Writes container size + item positions to the DOM. Idempotent — guarded
+  // by lastSize / lastPositions. Called from onChange (covers scroll-driven
+  // updates) and from a layout effect (covers post-render commits when refs
+  // have just registered new items in elementsCache).
+  const applyDirectStyles = (
+    instance: Virtualizer<TScrollElement, TItemElement>,
+  ) => {
+    const state = directRef.current
+    if (!state.enabled) return
+
+    const totalSize = instance.getTotalSize()
+    if (state.container && totalSize !== state.lastSize) {
+      state.lastSize = totalSize
+      const sizeAxis = instance.options.horizontal ? 'width' : 'height'
+      state.container.style[sizeAxis] = `${totalSize}px`
+    }
+
+    const horizontal = !!instance.options.horizontal
+    const useTransform = state.mode === 'transform'
+    const posAxis = horizontal ? 'left' : 'top'
+    const scrollMargin = instance.options.scrollMargin
+    const items = instance.getVirtualItems()
+    for (const item of items) {
+      const next = item.start - scrollMargin
+      const el = instance.elementsCache.get(item.key) as HTMLElement | undefined
+      if (!el) continue
+      if (state.lastPositions.get(el) === next) continue
+      state.lastPositions.set(el, next)
+      if (useTransform) {
+        el.style.transform = horizontal
+          ? `translate3d(${next}px, 0, 0)`
+          : `translate3d(0, ${next}px, 0)`
+      } else {
+        el.style[posAxis] = `${next}px`
+      }
+    }
+  }
+
   const resolvedOptions: VirtualizerOptions<TScrollElement, TItemElement> = {
     ...options,
     onChange: (instance, sync) => {
-      if (useFlushSync && sync) {
-        flushSync(rerender)
-      } else {
-        rerender()
+      const state = directRef.current
+      let shouldRerender = true
+
+      if (state.enabled) {
+        applyDirectStyles(instance)
+
+        // Only re-render on range / isScrolling changes
+        const range = instance.range
+        const prev = state.prevRange
+        shouldRerender =
+          !prev ||
+          prev.isScrolling !== instance.isScrolling ||
+          prev.startIndex !== range?.startIndex ||
+          prev.endIndex !== range?.endIndex
+        if (shouldRerender) {
+          state.prevRange = range
+            ? {
+                startIndex: range.startIndex,
+                endIndex: range.endIndex,
+                isScrolling: instance.isScrolling,
+              }
+            : null
+        }
       }
+
+      if (shouldRerender) {
+        if (useFlushSync && sync) {
+          flushSync(rerender)
+        } else {
+          rerender()
+        }
+      }
+
       options.onChange?.(instance, sync)
     },
   }
 
-  const [instance] = React.useState(
-    () => new Virtualizer<TScrollElement, TItemElement>(resolvedOptions),
-  )
+  const [instance] = React.useState(() => {
+    const v = new Virtualizer<TScrollElement, TItemElement>(
+      resolvedOptions,
+    ) as ReactVirtualizer<TScrollElement, TItemElement>
+    v.containerRef = (node: HTMLElement | null) => {
+      const state = directRef.current
+      state.container = node
+      state.lastSize = null
+      if (node && state.enabled) {
+        const total = v.getTotalSize()
+        state.lastSize = total
+        const axis = v.options.horizontal ? 'width' : 'height'
+        node.style[axis] = `${total}px`
+      }
+    }
+    return v
+  })
 
   instance.setOptions(resolvedOptions)
 
@@ -59,6 +204,13 @@ function useVirtualizerBase<
 
   useIsomorphicLayoutEffect(() => {
     return instance._willUpdate()
+  })
+
+  // After every render commit, newly mounted item refs have registered in
+  // elementsCache; write their positions to the DOM so the user doesn't see
+  // them at (0, 0) until the next onChange.
+  useIsomorphicLayoutEffect(() => {
+    applyDirectStyles(instance)
   })
 
   return instance
@@ -72,7 +224,7 @@ export function useVirtualizer<
     ReactVirtualizerOptions<TScrollElement, TItemElement>,
     'observeElementRect' | 'observeElementOffset' | 'scrollToFn'
   >,
-): Virtualizer<TScrollElement, TItemElement> {
+): ReactVirtualizer<TScrollElement, TItemElement> {
   return useVirtualizerBase<TScrollElement, TItemElement>({
     observeElementRect: observeElementRect,
     observeElementOffset: observeElementOffset,
@@ -89,7 +241,7 @@ export function useWindowVirtualizer<TItemElement extends Element>(
     | 'observeElementOffset'
     | 'scrollToFn'
   >,
-): Virtualizer<Window, TItemElement> {
+): ReactVirtualizer<Window, TItemElement> {
   return useVirtualizerBase<Window, TItemElement>({
     getScrollElement: () => (typeof document !== 'undefined' ? window : null),
     observeElementRect: observeWindowRect,


### PR DESCRIPTION
Adds opt-in `directDomUpdates` to `useVirtualizer` / `useWindowVirtualizer`. When enabled, item positions (top/left or transform) and container size (height/width) are written directly to the DOM on every onChange, and React only re-renders on range or isScrolling changes.

- New `directDomUpdatesMode: 'position' | 'transform'` to pick strategy
- New `virtualizer.containerRef` for the inner sized element

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in direct DOM updates for the virtualized list with selectable positioning modes (position/transform) for smoother scrolling and reduced rerenders.
  * Exposed container hookup to enable immediate sizing and direct positioning behavior.

* **Tests**
  * Added end-to-end tests covering direct DOM updates across positioning modes, scroll behaviors, and render-count assertions.

* **Chores**
  * Release note entry added to mark the opt-in feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->