### PR TITLE
feat(virtual-core): skip sync DOM read in measureElement when cached size exists

### DIFF
--- a/.changeset/skip-sync-measure-cached.md
+++ b/.changeset/skip-sync-measure-cached.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Skip synchronous DOM read (offsetWidth/offsetHeight) in default measureElement when a cached size already exists, reducing layout reflow on re-renders

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -252,6 +252,21 @@ export const measureElement = <TItemElement extends Element>(
     }
   }
 
+  // When called without a ResizeObserverEntry (sync measurement path),
+  // return the previously measured size if available. This avoids a
+  // synchronous layout read (offsetWidth/offsetHeight) on re-renders.
+  // The ResizeObserver is already observing the element and will deliver
+  // the accurate size asynchronously if it changed.
+  // Users who need synchronous DOM reads can provide a custom measureElement.
+  if (!entry) {
+    const index = instance.indexFromElement(element)
+    const key = instance.options.getItemKey(index)
+    const cachedSize = instance.itemSizeCache.get(key)
+    if (cachedSize !== undefined) {
+      return cachedSize
+    }
+  }
+
   return (element as unknown as HTMLElement)[
     instance.options.horizontal ? 'offsetWidth' : 'offsetHeight'
   ]
@@ -382,7 +397,7 @@ export class Virtualizer<
   // Flat backing store for the lanes===1 fast path: [start_0, size_0, start_1, size_1, ...].
   // null until the first single-lane build; reused (and grown) across rebuilds.
   private _flatMeasurements: Float64Array | null = null
-  private itemSizeCache = new Map<Key, number>()
+  itemSizeCache = new Map<Key, number>()
   private itemSizeCacheVersion = 0
   private laneAssignments = new Map<number, number>() // index → lane cache
   // Earliest index dirtied since last getMeasurements() rebuild, or null.


### PR DESCRIPTION
This PR skip synchronous DOM reads (`offsetWidth`/`offsetHeight`) in the default `measureElement` when a cached size already exists.

Reading `offsetWidth`/`offsetHeight` forces browser layout reflow. On re-renders, this is redundant, the `ResizeObserver` is already watching the element and will fire if the size changes.


## 🎯 Changes

This PR skips the sync DOM read when the item already has a measured size in `itemSizeCache`, returning the cached value instead. The `ResizeObserver` is already observing the element and will deliver an accurate size asynchronously if it changed. First mount still does the sync read since no cache exists yet.

`itemSizeCache` is made public so the standalone `measureElement` function can access it (same pattern as the existing public `elementsCache`). Users who need sync DOM reads on every render can pass a custom `measureElement`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved rendering performance by reusing cached element sizes to avoid unnecessary synchronous DOM reads and reduce layout reflows during re-renders.
  * Made the internal item-size cache accessible, allowing advanced users to inspect and manage cached measurements for fine-grained control and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->