### PR TITLE
docs: add directDomUpdates and directDomUpdatesMode options

### DIFF
--- a/docs/framework/react/react-virtual.md
+++ b/docs/framework/react/react-virtual.md
@@ -73,3 +73,73 @@ const virtualizer = useVirtualizer({
   useFlushSync: false, // Disable synchronous updates
 })
 ```
+
+### `directDomUpdates`
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Skip React re-renders for scroll-only updates. When enabled, the virtualizer writes item positions (`top`/`left` or `transform`) and the container size (`height`/`width`) directly to the DOM, and only re-renders when the visible index range or `isScrolling` changes.
+
+#### Requirements when enabled
+
+- Item elements must be `position: absolute`; in `'transform'` mode they must also be anchored with `top: 0` / `left: 0`.
+- Item elements must **not** set the main-axis position in their style — the virtualizer owns `top` / `left` in `'position'` mode and `transform` in `'transform'` mode.
+- The inner sized container must receive `virtualizer.containerRef` and must **not** set `height` / `width` in its style.
+- For multi-lane layouts (grids / masonry), the cross-axis position (e.g. `left: ${(item.lane * 100) / lanes}%`) is stable per item and must still be set in your JSX — only the main axis is automated.
+
+> ⚠️ This flag is intended to be set once at mount. Toggling it (or `directDomUpdatesMode`) at runtime can leave stale inline styles on items and the container.
+
+#### Example
+
+```tsx
+const virtualizer = useVirtualizer({
+  count: 10000,
+  getScrollElement: () => parentRef.current,
+  estimateSize: () => 50,
+  directDomUpdates: true,
+})
+
+return (
+  <div ref={parentRef} style={{ overflow: 'auto', height: 400 }}>
+    {/* The inner container must use virtualizer.containerRef and not set height */}
+    <div ref={virtualizer.containerRef} style={{ position: 'relative' }}>
+      {virtualizer.getVirtualItems().map((item) => (
+        <div
+          key={item.key}
+          ref={virtualizer.measureElement}
+          data-index={item.index}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            // Do NOT set top/left/transform — the virtualizer handles it
+          }}
+        >
+          Row {item.index}
+        </div>
+      ))}
+    </div>
+  </div>
+)
+```
+
+### `directDomUpdatesMode`
+
+- **Type**: `'position' | 'transform'`
+- **Default**: `'transform'`
+- **Description**: Controls how `directDomUpdates` positions item elements.
+  - `'transform'` (default): writes `transform: translate3d(...)`. Promotes items to their own compositor layer — usually smoother on long lists, but creates a stacking context and can interfere with `position: fixed` descendants. Item elements must be anchored with `position: absolute`, `top: 0`, and `left: 0`.
+  - `'position'`: writes `top` / `left`. Item elements must be `position: absolute`.
+
+#### Example
+
+```tsx
+const virtualizer = useVirtualizer({
+  count: 10000,
+  getScrollElement: () => parentRef.current,
+  estimateSize: () => 50,
+  directDomUpdates: true,
+  directDomUpdatesMode: 'position', // Use top/left instead of transform
+})
+```

--- a/docs/framework/react/react-virtual.md
+++ b/docs/framework/react/react-virtual.md
@@ -84,7 +84,7 @@ const virtualizer = useVirtualizer({
 
 - Item elements must be `position: absolute`; in `'transform'` mode they must also be anchored with `top: 0` / `left: 0`.
 - Item elements must **not** set the main-axis position in their style — the virtualizer owns `top` / `left` in `'position'` mode and `transform` in `'transform'` mode.
-- The inner sized container must receive `virtualizer.containerRef` and must **not** set `height` / `width` in its style.
+- The inner size container must receive `virtualizer.containerRef` and must **not** set `height` / `width` in its style.
 - For multi-lane layouts (grids / masonry), the cross-axis position (e.g. `left: ${(item.lane * 100) / lanes}%`) is stable per item and must still be set in your JSX — only the main axis is automated.
 
 > ⚠️ This flag is intended to be set once at mount. Toggling it (or `directDomUpdatesMode`) at runtime can leave stale inline styles on items and the container.

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -21,7 +21,7 @@ export type ReactVirtualizer<
   TItemElement extends Element,
 > = Virtualizer<TScrollElement, TItemElement> & {
   /**
-   * Ref callback for the inner sized container element. Only meaningful when
+   * Ref callback for the inner size container element. Only meaningful when
    * `directDomUpdates: true` — the virtualizer writes the container's
    * main-axis size (`height` or `width`) directly to skip React re-renders.
    */
@@ -45,7 +45,7 @@ export type ReactVirtualizerOptions<
    * - Item elements must NOT set the main-axis position in their style — the
    *   virtualizer owns `top` / `left` in `'position'` mode and `transform` in
    *   `'transform'` mode.
-   * - The inner sized container must receive `virtualizer.containerRef` and
+   * - The inner size container must receive `virtualizer.containerRef` and
    *   must NOT set `height` / `width` in its style.
    * - For multi-lane layouts (grids / masonry), the cross-axis position
    *   (e.g. `left: ${(item.lane * 100) / lanes}%`) is stable per item and


### PR DESCRIPTION
## 🎯 Changes

Add missing documentation for the directDomUpdates and directDomUpdatesMode React-specific options to the React Virtual docs page.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation for two React Virtualizer options—directDomUpdates and directDomUpdatesMode—including how to enable them, required layout/positioning constraints, guidance on choosing between positioning modes, example usage, and a caution about toggling these options at runtime to avoid stale inline styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->