### PR TITLE
Replaced ReactDOM.render with createRoot in React padding example

### DIFF
--- a/examples/react/padding/src/main.tsx
+++ b/examples/react/padding/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 
 import './index.css'
 
@@ -256,9 +256,10 @@ function GridVirtualizerDynamic({
   )
 }
 
-ReactDOM.render(
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root'),
 )


### PR DESCRIPTION
Replaced `ReactDOM.render` with `createRoot `in React padding example as the example was not even showing any preview in the [docs](https://tanstack.com/virtual/latest/docs/framework/react/examples/padding?panel=sandbox). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's React configuration to align with React 18's current API standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->