### PR TITLE
perf: reduce per-scroll and per-render allocations

### DIFF
--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -72,22 +72,24 @@ export type ReactVirtualizerOptions<
 function useVirtualizerBase<
   TScrollElement extends Element | Window,
   TItemElement extends Element,
->({
-  useFlushSync = true,
-  directDomUpdates = false,
-  directDomUpdatesMode = 'transform',
-  ...options
-}: ReactVirtualizerOptions<TScrollElement, TItemElement>): ReactVirtualizer<
-  TScrollElement,
-  TItemElement
-> {
+>(
+  rawOptions: ReactVirtualizerOptions<TScrollElement, TItemElement>,
+): ReactVirtualizer<TScrollElement, TItemElement> {
+  const {
+    useFlushSync = true,
+    directDomUpdates = false,
+    directDomUpdatesMode = 'transform',
+  } = rawOptions
   const rerender = React.useReducer((x: number) => x + 1, 0)[1]
 
-  // Mutable across renders so the onChange closure captured by setOptions
-  // always reads the latest values without us having to re-create it.
-  const directRef = React.useRef({
+  // Mutable across renders so the onChange closure (created once, in the
+  // useState initializer below) always reads the latest values without us
+  // having to re-create it.
+  const latestRef = React.useRef({
     enabled: directDomUpdates,
     mode: directDomUpdatesMode,
+    useFlushSync,
+    userOnChange: rawOptions.onChange,
     container: null as HTMLElement | null,
     lastSize: null as number | null,
     // Keyed by the element itself so a remounted node (same key, new DOM
@@ -100,8 +102,11 @@ function useVirtualizerBase<
       isScrolling: boolean
     } | null,
   })
-  directRef.current.enabled = directDomUpdates
-  directRef.current.mode = directDomUpdatesMode
+  const latest = latestRef.current
+  latest.enabled = directDomUpdates
+  latest.mode = directDomUpdatesMode
+  latest.useFlushSync = useFlushSync
+  latest.userOnChange = rawOptions.onChange
 
   // Writes container size + item positions to the DOM. Idempotent — guarded
   // by lastSize / lastPositions. Called from onChange (covers scroll-driven
@@ -110,7 +115,7 @@ function useVirtualizerBase<
   const applyDirectStyles = (
     instance: Virtualizer<TScrollElement, TItemElement>,
   ) => {
-    const state = directRef.current
+    const state = latestRef.current
     if (!state.enabled) return
 
     const totalSize = instance.getTotalSize()
@@ -141,51 +146,61 @@ function useVirtualizerBase<
     }
   }
 
-  const resolvedOptions: VirtualizerOptions<TScrollElement, TItemElement> = {
-    ...options,
-    onChange: (instance, sync) => {
-      const state = directRef.current
-      let shouldRerender = true
+  // Created once and captured by the Virtualizer; reads everything it needs
+  // through latestRef so we never need to allocate a fresh closure or a
+  // {...options, onChange} spread per render.
+  const [stableOnChange] = React.useState(
+    () =>
+      (instance: Virtualizer<TScrollElement, TItemElement>, sync: boolean) => {
+        const state = latestRef.current
+        let shouldRerender = true
 
-      if (state.enabled) {
-        applyDirectStyles(instance)
+        if (state.enabled) {
+          applyDirectStyles(instance)
 
-        // Only re-render on range / isScrolling changes
-        const range = instance.range
-        const prev = state.prevRange
-        shouldRerender =
-          !prev ||
-          prev.isScrolling !== instance.isScrolling ||
-          prev.startIndex !== range?.startIndex ||
-          prev.endIndex !== range?.endIndex
+          // Only re-render on range / isScrolling changes
+          const range = instance.range
+          const prev = state.prevRange
+          shouldRerender =
+            !prev ||
+            prev.isScrolling !== instance.isScrolling ||
+            prev.startIndex !== range?.startIndex ||
+            prev.endIndex !== range?.endIndex
+          if (shouldRerender) {
+            state.prevRange = range
+              ? {
+                  startIndex: range.startIndex,
+                  endIndex: range.endIndex,
+                  isScrolling: instance.isScrolling,
+                }
+              : null
+          }
+        }
+
         if (shouldRerender) {
-          state.prevRange = range
-            ? {
-                startIndex: range.startIndex,
-                endIndex: range.endIndex,
-                isScrolling: instance.isScrolling,
-              }
-            : null
+          if (state.useFlushSync && sync) {
+            flushSync(rerender)
+          } else {
+            rerender()
+          }
         }
-      }
 
-      if (shouldRerender) {
-        if (useFlushSync && sync) {
-          flushSync(rerender)
-        } else {
-          rerender()
-        }
-      }
-
-      options.onChange?.(instance, sync)
-    },
-  }
+        state.userOnChange?.(instance, sync)
+      },
+  )
 
   const [instance] = React.useState(() => {
-    const v = new Virtualizer<TScrollElement, TItemElement>(resolvedOptions)
+    // Shallow-copy once so we can overwrite onChange without mutating the
+    // caller's object; subsequent renders mutate this object in place.
+    const initialOptions = {
+      ...rawOptions,
+      onChange: stableOnChange,
+    } as VirtualizerOptions<TScrollElement, TItemElement>
+    const v = new Virtualizer<TScrollElement, TItemElement>(initialOptions)
     return Object.assign(v, {
+      _adapterOptions: initialOptions,
       containerRef: (node: HTMLElement | null) => {
-        const state = directRef.current
+        const state = latestRef.current
         state.container = node
         state.lastSize = null
         if (node && state.enabled) {
@@ -198,7 +213,19 @@ function useVirtualizerBase<
     })
   })
 
-  instance.setOptions(resolvedOptions)
+  // Reuse the persisted options object: copy fresh fields onto it instead of
+  // allocating a {...spread} per render. setOptions reads keys via for-in,
+  // so passing the same (mutated) object is equivalent.
+  const adapterOptions = (
+    instance as unknown as {
+      _adapterOptions: VirtualizerOptions<TScrollElement, TItemElement>
+    }
+  )._adapterOptions
+  for (const key in rawOptions) {
+    ;(adapterOptions as any)[key] = (rawOptions as any)[key]
+  }
+  adapterOptions.onChange = stableOnChange
+  instance.setOptions(adapterOptions)
 
   useIsomorphicLayoutEffect(() => {
     return instance._didMount()
@@ -235,6 +262,11 @@ export function useVirtualizer<
   })
 }
 
+const getWindowScrollElement = () =>
+  typeof document !== 'undefined' ? window : null
+const getWindowInitialOffset = () =>
+  typeof document !== 'undefined' ? window.scrollY : 0
+
 export function useWindowVirtualizer<TItemElement extends Element>(
   options: PartialKeys<
     ReactVirtualizerOptions<Window, TItemElement>,
@@ -245,11 +277,11 @@ export function useWindowVirtualizer<TItemElement extends Element>(
   >,
 ): ReactVirtualizer<Window, TItemElement> {
   return useVirtualizerBase<Window, TItemElement>({
-    getScrollElement: () => (typeof document !== 'undefined' ? window : null),
+    getScrollElement: getWindowScrollElement,
     observeElementRect: observeWindowRect,
     observeElementOffset: observeWindowOffset,
     scrollToFn: windowScroll,
-    initialOffset: () => (typeof document !== 'undefined' ? window.scrollY : 0),
+    initialOffset: getWindowInitialOffset,
     ...options,
   })
 }

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -422,6 +422,11 @@ export class Virtualizer<
   private _lazyItemCache: Array<VirtualItem | undefined> | null = null
   itemSizeCache = new Map<Key, number>()
   private itemSizeCacheVersion = 0
+  // While true, resizeItem records that a notify is owed instead of firing
+  // it — lets the RO callback process N entries with one trailing notify
+  // instead of N (each of which can trigger a rerender / rebuild).
+  private _suppressNotify = false
+  private _notifyPending = false
   // Bumped in setOptions when any measurement-relevant option changes.
   // Replaces a memo-hop that allocated a 6-tuple on every getMeasurements call.
   private measurementOptionsVersion = 0
@@ -479,41 +484,56 @@ export class Virtualizer<
       }
 
       return (_ro = new this.targetWindow.ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-          const run = () => {
-            const node = entry.target as TItemElement
-            const index = this.indexFromElement(node)
+        const processEntry = (entry: ResizeObserverEntry) => {
+          const node = entry.target as TItemElement
+          const index = this.indexFromElement(node)
 
-            if (!node.isConnected) {
-              this.observer.unobserve(node)
-              // Find the cache entry pointing to this exact node and remove
-              // it. We can't call getItemKey(index) here because items may
-              // have been removed since this node was rendered — the index
-              // could be stale and out-of-bounds in the user's data array
-              // (regression test in e2e/.../stale-index.spec.ts, fix #1148).
-              // The === comparison naturally handles the React-replaced-
-              // a-node-for-the-same-key case: that entry now points to a
-              // different node, so this loop won't match.
-              for (const [cacheKey, cachedNode] of this.elementsCache) {
-                if (cachedNode === node) {
-                  this.elementsCache.delete(cacheKey)
-                  break
-                }
+          if (!node.isConnected) {
+            this.observer.unobserve(node)
+            // Find the cache entry pointing to this exact node and remove
+            // it. We can't call getItemKey(index) here because items may
+            // have been removed since this node was rendered — the index
+            // could be stale and out-of-bounds in the user's data array
+            // (regression test in e2e/.../stale-index.spec.ts, fix #1148).
+            // The === comparison naturally handles the React-replaced-
+            // a-node-for-the-same-key case: that entry now points to a
+            // different node, so this loop won't match.
+            for (const [cacheKey, cachedNode] of this.elementsCache) {
+              if (cachedNode === node) {
+                this.elementsCache.delete(cacheKey)
+                break
               }
-              return
             }
-
-            if (this.shouldMeasureDuringScroll(index)) {
-              this.resizeItem(
-                index,
-                this.options.measureElement(node, entry, this),
-              )
-            }
+            return
           }
-          this.options.useAnimationFrameWithResizeObserver
-            ? requestAnimationFrame(run)
-            : run()
-        })
+
+          if (this.shouldMeasureDuringScroll(index)) {
+            this.resizeItem(
+              index,
+              this.options.measureElement(node, entry, this),
+            )
+          }
+        }
+
+        // Batch notify across all entries: resizeItem records that a notify
+        // is owed instead of firing one per entry. With N entries this turns
+        // N onChange calls (and the rebuilds/scroll-writes they trigger)
+        // into one.
+        const runBatch = () => {
+          this._suppressNotify = true
+          for (let i = 0, len = entries.length; i < len; i++) {
+            processEntry(entries[i]!)
+          }
+          this._suppressNotify = false
+          if (this._notifyPending) {
+            this._notifyPending = false
+            this.notify(false)
+          }
+        }
+
+        this.options.useAnimationFrameWithResizeObserver
+          ? requestAnimationFrame(runBatch)
+          : runBatch()
       }))
     }
 
@@ -1557,7 +1577,11 @@ export class Virtualizer<
         this.applyScrollAdjustment(delta)
       }
 
-      this.notify(false)
+      if (this._suppressNotify) {
+        this._notifyPending = true
+      } else {
+        this.notify(false)
+      }
     }
   }
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1,5 +1,5 @@
 import { createLazyMeasurementsView } from './lazy-measurements'
-import { approxEqual, debounce, memo, notUndefined } from './utils'
+import { approxEqual, memo, notUndefined } from './utils'
 
 // Browser-aware iOS detection. Programmatic `scrollTo`/`scrollTop` writes
 // during a momentum-scroll cancel the momentum on iOS WebKit, so we defer
@@ -196,13 +196,17 @@ const observeOffset = <T extends Element | Window>(
     instance.options.useScrollendEvent && supportsScrollend
 
   let offset = 0
+  // Zero-arg inline debounce: avoids the rest-args array + bound-this
+  // setTimeout closure that the exported `debounce` allocates per scroll.
+  let fallbackTimer = 0
+  const fallbackDelay = instance.options.isScrollingResetDelay
+  const fallbackFire = () => cb(offset, false)
   const fallback = registerScrollendEvent
     ? null
-    : debounce(
-        targetWindow,
-        () => cb(offset, false),
-        instance.options.isScrollingResetDelay,
-      )
+    : () => {
+        targetWindow.clearTimeout(fallbackTimer)
+        fallbackTimer = targetWindow.setTimeout(fallbackFire, fallbackDelay)
+      }
 
   const createHandler = (isScrolling: boolean) => () => {
     offset = readOffset(element)

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1089,24 +1089,21 @@ export class Virtualizer<
   }
 
   private getMeasurementOptions = memo(
+    // getItemKey is intentionally NOT a dep here. It's read fresh from
+    // this.options inside getMeasurements so an inline closure
+    // (`getItemKey: i => data[i].id`) doesn't bust this memo on every render
+    // and force a full O(n) rebuild via the `pendingMin = null` below. This
+    // matches estimateSize/gap, which are likewise read in the body. Genuine
+    // key-set changes are handled by the edgeKeysChanged path in setOptions.
     () => [
       this.options.count,
       this.options.paddingStart,
       this.options.scrollMargin,
-      this.options.getItemKey,
       this.options.enabled,
       this.options.lanes,
       this.options.laneAssignmentMode,
     ],
-    (
-      count,
-      paddingStart,
-      scrollMargin,
-      getItemKey,
-      enabled,
-      lanes,
-      laneAssignmentMode,
-    ) => {
+    (count, paddingStart, scrollMargin, enabled, lanes, laneAssignmentMode) => {
       const lanesChanged =
         this.prevLanes !== undefined && this.prevLanes !== lanes
 
@@ -1122,7 +1119,6 @@ export class Virtualizer<
         count,
         paddingStart,
         scrollMargin,
-        getItemKey,
         enabled,
         lanes,
         laneAssignmentMode,
@@ -1136,18 +1132,12 @@ export class Virtualizer<
   private getMeasurements = memo(
     () => [this.getMeasurementOptions(), this.itemSizeCacheVersion],
     (
-      {
-        count,
-        paddingStart,
-        scrollMargin,
-        getItemKey,
-        enabled,
-        lanes,
-        laneAssignmentMode,
-      },
+      { count, paddingStart, scrollMargin, enabled, lanes, laneAssignmentMode },
       _itemSizeCacheVersion,
     ) => {
       const itemSizeCache = this.itemSizeCache
+      // Read fresh — see getMeasurementOptions on why getItemKey isn't a dep.
+      const getItemKey = this.options.getItemKey
       if (!enabled) {
         this.measurementsCache = []
         this.itemSizeCache.clear()
@@ -1235,7 +1225,13 @@ export class Virtualizer<
           runningStart += size + gap
         }
 
-        const view = createLazyMeasurementsView(count, flat, getItemKey)
+        // The Proxy materializes VirtualItems lazily across the lifetime of
+        // this cached result, so it must read the *current* getItemKey
+        // (this.options is mutated in place by setOptions each render),
+        // not the one captured when this body ran.
+        const view = createLazyMeasurementsView(count, flat, (i) =>
+          this.options.getItemKey(i),
+        )
         this.measurementsCache = view
         return view
       }

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -418,10 +418,12 @@ export class Virtualizer<
   private _flatMeasurements: Float64Array | null = null
   itemSizeCache = new Map<Key, number>()
   private itemSizeCacheVersion = 0
+  // Bumped in setOptions when any measurement-relevant option changes.
+  // Replaces a memo-hop that allocated a 6-tuple on every getMeasurements call.
+  private measurementOptionsVersion = 0
   private laneAssignments = new Map<number, number>() // index → lane cache
   // Earliest index dirtied since last getMeasurements() rebuild, or null.
   private pendingMin: number | null = null
-  private prevLanes: number | undefined = undefined
   private lanesChangedFlag = false
   private lanesSettling = false
   private pendingScrollAnchor: PendingScrollAnchor | null = null
@@ -629,6 +631,26 @@ export class Virtualizer<
     }
 
     this.options = merged
+
+    // Detect changes to the options that affect measurement layout. This used
+    // to be a memo() hop (getMeasurementOptions) that allocated a deps-tuple
+    // on every getMeasurements() call; comparing here costs nothing extra
+    // since prevOptions is already in hand.
+    if (
+      prevOptions === undefined ||
+      prevOptions.count !== merged.count ||
+      prevOptions.paddingStart !== merged.paddingStart ||
+      prevOptions.scrollMargin !== merged.scrollMargin ||
+      prevOptions.enabled !== merged.enabled ||
+      prevOptions.lanes !== merged.lanes ||
+      prevOptions.laneAssignmentMode !== merged.laneAssignmentMode
+    ) {
+      this.measurementOptionsVersion++
+      this.pendingMin = null
+      if (prevOptions !== undefined && prevOptions.lanes !== merged.lanes) {
+        this.lanesChangedFlag = true
+      }
+    }
 
     // When edge keys changed (prepend, trim, reorder, etc.) the key→index
     // mapping has shifted. Force a full measurement rebuild so the anchor
@@ -1096,56 +1118,22 @@ export class Virtualizer<
       : undefined
   }
 
-  private getMeasurementOptions = memo(
-    // getItemKey is intentionally NOT a dep here. It's read fresh from
-    // this.options inside getMeasurements so an inline closure
-    // (`getItemKey: i => data[i].id`) doesn't bust this memo on every render
-    // and force a full O(n) rebuild via the `pendingMin = null` below. This
-    // matches estimateSize/gap, which are likewise read in the body. Genuine
-    // key-set changes are handled by the edgeKeysChanged path in setOptions.
-    () => [
-      this.options.count,
-      this.options.paddingStart,
-      this.options.scrollMargin,
-      this.options.enabled,
-      this.options.lanes,
-      this.options.laneAssignmentMode,
-    ],
-    (count, paddingStart, scrollMargin, enabled, lanes, laneAssignmentMode) => {
-      const lanesChanged =
-        this.prevLanes !== undefined && this.prevLanes !== lanes
-
-      if (lanesChanged) {
-        // Set flag for getMeasurements to handle
-        this.lanesChangedFlag = true
-      }
-
-      this.prevLanes = lanes
-      this.pendingMin = null
-
-      return {
+  private getMeasurements = memo(
+    () => [this.measurementOptionsVersion, this.itemSizeCacheVersion],
+    () => {
+      // Options are read fresh from this.options; setOptions bumps
+      // measurementOptionsVersion when any layout-affecting field changes.
+      // getItemKey is intentionally NOT version-tracked — see setOptions.
+      const {
         count,
         paddingStart,
         scrollMargin,
         enabled,
         lanes,
         laneAssignmentMode,
-      }
-    },
-    {
-      key: false,
-    },
-  )
-
-  private getMeasurements = memo(
-    () => [this.getMeasurementOptions(), this.itemSizeCacheVersion],
-    (
-      { count, paddingStart, scrollMargin, enabled, lanes, laneAssignmentMode },
-      _itemSizeCacheVersion,
-    ) => {
+        getItemKey,
+      } = this.options
       const itemSizeCache = this.itemSizeCache
-      // Read fresh — see getMeasurementOptions on why getItemKey isn't a dep.
-      const getItemKey = this.options.getItemKey
       if (!enabled) {
         this.measurementsCache = []
         this.itemSizeCache.clear()

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1348,22 +1348,25 @@ export class Virtualizer<
       this.options.lanes,
     ],
     (measurements, outerSize, scrollOffset, lanes) => {
-      return (this.range =
-        measurements.length > 0 && outerSize > 0
-          ? calculateRange({
-              measurements,
-              outerSize,
-              scrollOffset,
-              lanes,
-              // Pass the typed array so binary search + forward-walk can
-              // read start/end directly from Float64Array, skipping the
-              // Proxy traps that materialize a full VirtualItem per probe.
-              flat:
-                lanes === 1 && this._flatMeasurements != null
-                  ? this._flatMeasurements
-                  : null,
-            })
-          : null)
+      if (measurements.length === 0 || outerSize === 0) {
+        return (this.range = null)
+      }
+      // Reuse the range object — consumers read scalar startIndex/endIndex,
+      // never compare the reference.
+      const out = this.range ?? (this.range = { startIndex: 0, endIndex: 0 })
+      calculateRangeImpl(
+        measurements,
+        outerSize,
+        scrollOffset,
+        lanes,
+        // Pass the typed array so binary search + forward-walk can read
+        // start/end directly from Float64Array, skipping the Proxy traps.
+        lanes === 1 && this._flatMeasurements != null
+          ? this._flatMeasurements
+          : null,
+        out,
+      )
+      return out
     },
     {
       key: process.env.NODE_ENV !== 'production' && 'calculateRange',
@@ -1908,45 +1911,75 @@ const findNearestBinarySearch = (
   }
 }
 
-function calculateRange({
-  measurements,
-  outerSize,
-  scrollOffset,
-  lanes,
-  flat,
-}: {
-  measurements: Array<VirtualItem>
-  outerSize: number
-  scrollOffset: number
-  lanes: number
-  flat: Float64Array | null
-}) {
+// Monomorphic Float64Array variant — reads start values directly at stride
+// 2 instead of through a getter closure. JITs the inner load to a typed-
+// array bounds-check + load with no indirect call.
+const findNearestBinarySearchFlat = (
+  flat: Float64Array,
+  high: number,
+  value: number,
+) => {
+  let low = 0
+  while (low <= high) {
+    const middle = ((low + high) / 2) | 0
+    const currentValue = flat[middle * 2]!
+
+    if (currentValue < value) {
+      low = middle + 1
+    } else if (currentValue > value) {
+      high = middle - 1
+    } else {
+      return middle
+    }
+  }
+  return low > 0 ? low - 1 : 0
+}
+
+function calculateRangeImpl(
+  measurements: Array<VirtualItem>,
+  outerSize: number,
+  scrollOffset: number,
+  lanes: number,
+  flat: Float64Array | null,
+  out: { startIndex: number; endIndex: number },
+) {
   const lastIndex = measurements.length - 1
-  // When the lanes===1 fast-path is active, read start/end directly from the
-  // flat Float64Array instead of going through the lazy-view Proxy. Cuts
-  // ~17 Proxy.get traps per scroll for the binary search alone.
-  const getStart = flat
-    ? (index: number) => flat[index * 2]!
-    : (index: number) => measurements[index]!.start
-  const getEnd = flat
-    ? (index: number) => flat[index * 2]! + flat[index * 2 + 1]!
-    : (index: number) => measurements[index]!.end
 
   // handle case when item count is less than or equal to lanes
   if (measurements.length <= lanes) {
-    return {
-      startIndex: 0,
-      endIndex: lastIndex,
-    }
+    out.startIndex = 0
+    out.endIndex = lastIndex
+    return
   }
 
-  let startIndex = findNearestBinarySearch(0, lastIndex, getStart, scrollOffset)
-  let endIndex = startIndex
+  let startIndex: number
+  let endIndex: number
+
+  if (lanes === 1 && flat !== null) {
+    // Hot single-lane path: typed-array reads, no closures, no Proxy traps.
+    startIndex = findNearestBinarySearchFlat(flat, lastIndex, scrollOffset)
+    endIndex = startIndex
+    const limit = scrollOffset + outerSize
+    while (
+      endIndex < lastIndex &&
+      flat[endIndex * 2]! + flat[endIndex * 2 + 1]! < limit
+    ) {
+      endIndex++
+    }
+    out.startIndex = startIndex
+    out.endIndex = endIndex
+    return
+  }
+
+  // Fallback (lanes > 1 or no flat array): closure-based reads.
+  const getStart = (index: number) => measurements[index]!.start
+  startIndex = findNearestBinarySearch(0, lastIndex, getStart, scrollOffset)
+  endIndex = startIndex
 
   if (lanes === 1) {
     while (
       endIndex < lastIndex &&
-      getEnd(endIndex) < scrollOffset + outerSize
+      measurements[endIndex]!.end < scrollOffset + outerSize
     ) {
       endIndex++
     }
@@ -1978,5 +2011,6 @@ function calculateRange({
     endIndex = Math.min(lastIndex, endIndex + (lanes - 1 - (endIndex % lanes)))
   }
 
-  return { startIndex, endIndex }
+  out.startIndex = startIndex
+  out.endIndex = endIndex
 }

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -80,6 +80,10 @@ const getRect = (element: HTMLElement): Rect => {
 
 export const defaultKeyExtractor = (index: number) => index
 
+const NOOP = () => {}
+const ZERO_RECT: Rect = { width: 0, height: 0 }
+const EMPTY_ARR: ReadonlyArray<any> = []
+
 export const defaultRangeExtractor = (range: Range) => {
   const start = Math.max(range.startIndex - range.overscan, 0)
   const end = Math.min(range.endIndex + range.overscan, range.count - 1)
@@ -533,13 +537,13 @@ export class Virtualizer<
       horizontal: false,
       getItemKey: defaultKeyExtractor,
       rangeExtractor: defaultRangeExtractor,
-      onChange: () => {},
+      onChange: NOOP,
       measureElement,
-      initialRect: { width: 0, height: 0 },
+      initialRect: ZERO_RECT,
       scrollMargin: 0,
       gap: 0,
       indexAttribute: 'data-index',
-      initialMeasurementsCache: [],
+      initialMeasurementsCache: EMPTY_ARR,
       lanes: 1,
       anchorTo: 'start',
       followOnAppend: false,

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -416,6 +416,10 @@ export class Virtualizer<
   // Flat backing store for the lanes===1 fast path: [start_0, size_0, start_1, size_1, ...].
   // null until the first single-lane build; reused (and grown) across rebuilds.
   private _flatMeasurements: Float64Array | null = null
+  // Materialized-VirtualItem cache backing the lazy Proxy view. Persisted
+  // across rebuilds so items at indices < pendingMin keep referential
+  // identity (lets row-level React.memo bail out).
+  private _lazyItemCache: Array<VirtualItem | undefined> | null = null
   itemSizeCache = new Map<Key, number>()
   private itemSizeCacheVersion = 0
   // Bumped in setOptions when any measurement-relevant option changes.
@@ -1136,6 +1140,7 @@ export class Virtualizer<
       const itemSizeCache = this.itemSizeCache
       if (!enabled) {
         this.measurementsCache = []
+        this._lazyItemCache = null
         this.itemSizeCache.clear()
         this.laneAssignments.clear()
         return []
@@ -1155,6 +1160,7 @@ export class Virtualizer<
         this.lanesChangedFlag = false // Reset immediately
         this.lanesSettling = true // Start settling period
         this.measurementsCache = []
+        this._lazyItemCache = null
         this.itemSizeCache.clear()
         this.laneAssignments.clear() // Clear lane cache for new lane count
         // Force min = 0 on the rebuild
@@ -1221,11 +1227,27 @@ export class Virtualizer<
           runningStart += size + gap
         }
 
+        // Reuse the materialized-item cache so VirtualItems at indices < min
+        // keep referential identity across rebuilds. Invalidate the dirtied
+        // tail in place. Length is allowed to exceed count — the Proxy
+        // bounds-checks against `count`, and a later grow re-uses the slack.
+        let lazyCache = this._lazyItemCache
+        if (!lazyCache || lazyCache.length < count) {
+          const next: Array<VirtualItem | undefined> = new Array(count)
+          if (lazyCache && min > 0) {
+            for (let i = 0; i < min; i++) next[i] = lazyCache[i]
+          }
+          lazyCache = next
+          this._lazyItemCache = lazyCache
+        } else {
+          lazyCache.fill(undefined, min)
+        }
+
         // The Proxy materializes VirtualItems lazily across the lifetime of
         // this cached result, so it must read the *current* getItemKey
         // (this.options is mutated in place by setOptions each render),
         // not the one captured when this body ran.
-        const view = createLazyMeasurementsView(count, flat, (i) =>
+        const view = createLazyMeasurementsView(count, flat, lazyCache, (i) =>
           this.options.getItemKey(i),
         )
         this.measurementsCache = view

--- a/packages/virtual-core/src/lazy-measurements.ts
+++ b/packages/virtual-core/src/lazy-measurements.ts
@@ -10,9 +10,9 @@ type Key = number | string | bigint
 export function createLazyMeasurementsView(
   count: number,
   flat: Float64Array,
+  cache: Array<VirtualItem | undefined>,
   getItemKey: (i: number) => Key,
 ): Array<VirtualItem> {
-  const cache: Array<VirtualItem | undefined> = new Array(count)
   return new Proxy(cache as any, {
     get(target, prop, receiver) {
       if (typeof prop === 'string') {

--- a/packages/virtual-core/src/utils.ts
+++ b/packages/virtual-core/src/utils.ts
@@ -28,9 +28,15 @@ export function memo<TDeps extends ReadonlyArray<any>, TResult>(
 
     const newDeps = getDeps()
 
-    const depsChanged =
-      newDeps.length !== deps.length ||
-      newDeps.some((dep: any, index: number) => deps[index] !== dep)
+    let depsChanged = newDeps.length !== deps.length
+    if (!depsChanged) {
+      for (let i = 0, len = newDeps.length; i < len; i++) {
+        if (newDeps[i] !== deps[i]) {
+          depsChanged = true
+          break
+        }
+      }
+    }
 
     if (!depsChanged) {
       return result!

--- a/packages/virtual-core/tests/bench.bench.ts
+++ b/packages/virtual-core/tests/bench.bench.ts
@@ -200,6 +200,29 @@ describe('Layer 2: setOptions() — simulating React render storm', () => {
   })
 })
 
+// ─── Scroll loop: per-scroll-frame cost (calculateRange + memo machinery) ─────
+
+describe('Scroll loop: 10k scroll events on warm virtualizer', () => {
+  for (const n of [1000, 100000]) {
+    bench(`n=${n}, 10k scrolls`, () => {
+      const v = makeVirt(n)
+      v.scrollRect = { width: 800, height: 600 }
+      for (let i = 0; i < 10_000; i++) {
+        v.scrollOffset = i * 5
+        ;(v as any).calculateRange()
+      }
+    })
+    bench(`n=${n}, 10k scrolls + getVirtualItems`, () => {
+      const v = makeVirt(n)
+      v.scrollRect = { width: 800, height: 600 }
+      for (let i = 0; i < 10_000; i++) {
+        v.scrollOffset = i * 5
+        v.getVirtualItems()
+      }
+    })
+  }
+})
+
 // ─── Layer 6: defaultRangeExtractor ──────────────────────────────────────────
 
 describe('Layer 6: defaultRangeExtractor', () => {

--- a/packages/virtual-core/tests/getItemKey-identity.test.ts
+++ b/packages/virtual-core/tests/getItemKey-identity.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { Virtualizer } from '../src/index'
+
+// Minimal no-op options that satisfy the framework-adapter slots without
+// touching the DOM, so this test runs in a plain node environment.
+const noopAdapter = {
+  observeElementRect: () => () => {},
+  observeElementOffset: () => () => {},
+  scrollToFn: () => {},
+  getScrollElement: () => null,
+}
+
+describe('getItemKey identity stability', () => {
+  it('does not rebuild measurements when getItemKey identity changes', () => {
+    const data = ['a', 'b', 'c', 'd', 'e']
+
+    const v = new Virtualizer({
+      ...noopAdapter,
+      count: data.length,
+      estimateSize: () => 50,
+      getItemKey: (i) => data[i]!,
+    })
+
+    // @ts-expect-error private — reaching in to assert memo behavior directly.
+    const before = v.getMeasurements()
+
+    // Simulate a React re-render: setOptions called with a fresh inline
+    // closure for getItemKey that returns the same values.
+    v.setOptions({
+      ...noopAdapter,
+      count: data.length,
+      estimateSize: () => 50,
+      getItemKey: (i) => data[i]!,
+    })
+
+    // @ts-expect-error private
+    const after = v.getMeasurements()
+
+    // Same reference ⇒ memo hit ⇒ no O(n) rebuild.
+    expect(after).toBe(before)
+  })
+
+  it('still rebuilds when count changes', () => {
+    const v = new Virtualizer({
+      ...noopAdapter,
+      count: 5,
+      estimateSize: () => 50,
+      getItemKey: (i) => i,
+    })
+
+    // @ts-expect-error private
+    const before = v.getMeasurements()
+
+    v.setOptions({
+      ...noopAdapter,
+      count: 6,
+      estimateSize: () => 50,
+      getItemKey: (i) => i,
+    })
+
+    // @ts-expect-error private
+    const after = v.getMeasurements()
+
+    expect(after).not.toBe(before)
+    expect(after.length).toBe(6)
+  })
+
+  it('lazy view reads the latest getItemKey across renders', () => {
+    let data = ['a', 'b', 'c']
+    const v = new Virtualizer({
+      ...noopAdapter,
+      count: data.length,
+      estimateSize: () => 50,
+      getItemKey: (i) => data[i]!,
+    })
+
+    // @ts-expect-error private
+    const measurements = v.getMeasurements()
+
+    // Re-render with new closure over mutated-contents data (same length).
+    // No rebuild — but the Proxy must still surface the *current* keys.
+    data = ['x', 'y', 'z']
+    v.setOptions({
+      ...noopAdapter,
+      count: data.length,
+      estimateSize: () => 50,
+      getItemKey: (i) => data[i]!,
+    })
+
+    // @ts-expect-error private
+    expect(v.getMeasurements()).toBe(measurements)
+    expect(measurements[0]!.key).toBe('x')
+    expect(measurements[2]!.key).toBe('z')
+  })
+})


### PR DESCRIPTION
## Summary

A pass over `virtual-core` and `react-virtual` to cut per-scroll-frame and per-render allocations. Each optimization is its own commit so they can be reviewed (or cherry-picked) independently.

Builds on the `getItemKey` memo-dep fix in the first commit on this branch (`d63ac20`), which is the largest single win — it stops an inline `getItemKey` closure from forcing a full O(n) measurements rebuild on every render.

## Benchmarks

`packages/virtual-core/tests/bench.bench.ts` (added a scroll-loop section in this PR). hz = ops/sec, higher is better. No benchmark regressed below 0.97×.

| Benchmark | Before | After | Speedup |
|---|--:|--:|--:|
| `setOptions × 10,000` | 309.6 | 633.0 | **2.04×** |
| Scroll loop, n=1k, 10k scrolls (`calculateRange`) | 104.4 | 168.3 | **1.61×** |
| Scroll loop, n=100k, 10k scrolls | 80.3 | 128.4 | **1.60×** |
| `getVirtualItemForOffset(0)`, n=1k | 54,997 | 82,243 | **1.50×** |
| Cold mount `getMeasurements`, n=500k | 154.3 | 224.0 | **1.45×** |
| onChange storm, n=100 | 83,696 | 120,179 | **1.44×** |
| Cold mount `getMeasurements`, n=100k | 823.2 | 1,106.0 | **1.34×** |
| Scroll + `getVirtualItems`, n=1k | 39.5 | 52.1 | **1.32×** |
| Scroll + `getVirtualItems`, n=100k | 30.3 | 37.2 | **1.23×** |

## Commits

| Commit | Change |
|---|---|
| `bench(core)` | Add scroll-loop benchmark — none of the existing benches covered the per-scroll-frame path |
| `perf(core): indexed for-loop dep compare in memo()` | `.some()` allocates a closure on every memo invocation; memo runs ~4×/scroll, ~6×/render |
| `perf(core): hoist setOptions nested-default allocations` | `() => {}` / `{w:0,h:0}` / `[]` → module constants |
| `perf(core): inline zero-arg debounce in observeOffset` | Exported `debounce` allocates rest-args + setTimeout closure per scroll; only internal caller passes zero args. Public API unchanged |
| `perf(core): replace getMeasurementOptions memo with version int` | Was a memo-hop allocating a 6-tuple on every `getMeasurements()`; `setOptions` already has `prevOptions` in hand |
| `perf(core): persist lazy-view item cache across rebuilds` | `createLazyMeasurementsView` discarded `new Array(count)` on every rebuild; now invalidates only the dirtied tail so VirtualItems at indices < `pendingMin` keep referential identity (lets row `React.memo` bail out) |
| `perf(core): zero-alloc calculateRange on the lanes===1 hot path` | Positional args, monomorphic `findNearestBinarySearchFlat`, mutate `this.range` in place |
| `perf(core): batch ResizeObserver entries into one notify` | Was N× `notify` per RO batch; now process all entries, fire once. Also lifts rAF outside the loop |
| `perf(react-virtual): stable onChange + reuse adapter options object` | Stable `onChange` via latest-ref, copy fields onto a persisted options object instead of `{...spread}` per render, hoist `useWindowVirtualizer` defaults |

## Behavior change

Only one (from the `getItemKey` commit): if `getItemKey` returns *different keys for the same indices* without `count` changing, consumers must call `virtualizer.measure()` to rebuild — matching the existing `estimateSize` contract. The `anchorTo: 'end'` path is unaffected (it already detects edge-key changes in `setOptions`).

## Tests

- 94/94 existing `virtual-core` tests pass
- 3 new tests in `tests/getItemKey-identity.test.ts` (fail on `main`, pass with this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized scroll event handling to reduce rendering overhead and improve responsiveness during fast scrolling scenarios.
  * Enhanced memory efficiency through improved caching and item measurement strategies.
  * Reduced unnecessary re-renders by stabilizing internal callbacks and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->