### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/angular-virtual/package.json
+++ b/packages/angular-virtual/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@angular/core": ">=19.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
+  }
 }

--- a/packages/lit-virtual/package.json
+++ b/packages/lit-virtual/package.json
@@ -60,5 +60,8 @@
   },
   "peerDependencies": {
     "lit": "^3.1.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
   }
 }

--- a/packages/react-virtual/package.json
+++ b/packages/react-virtual/package.json
@@ -70,5 +70,8 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
   }
 }

--- a/packages/solid-virtual/package.json
+++ b/packages/solid-virtual/package.json
@@ -60,5 +60,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
   }
 }

--- a/packages/svelte-virtual/package.json
+++ b/packages/svelte-virtual/package.json
@@ -57,5 +57,8 @@
   },
   "peerDependencies": {
     "svelte": "^3.48.0 || ^4.0.0 || ^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
   }
 }

--- a/packages/virtual-core/package.json
+++ b/packages/virtual-core/package.json
@@ -52,5 +52,8 @@
   "files": [
     "dist",
     "src"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
+  }
 }

--- a/packages/vue-virtual/package.json
+++ b/packages/vue-virtual/package.json
@@ -64,5 +64,8 @@
   },
   "peerDependencies": {
     "vue": "^2.7.0 || ^3.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/virtual/issues"
   }
 }


### PR DESCRIPTION
## Problem

All `@tanstack/virtual` packages are missing the `bugs` field in their `package.json` files.

```sh
npm view @tanstack/react-virtual bugs    # empty
npm view @tanstack/virtual-core bugs    # empty
# etc.
```

## Fix

Add `bugs.url` pointing to the GitHub issue tracker in all published packages. Metadata-only change — no runtime behaviour is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Enhanced issue reporting workflow by adding official bug tracking URLs to package metadata across all virtualization framework libraries. This provides developers with streamlined, direct access to the project's issue tracker for bug reporting.
- Improved package configuration consistency by correcting JSON structure and formatting across package manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->