### PR TITLE
fix(solid-virtual): preserve measurements on option updates

### DIFF
--- a/.changeset/quiet-cats-preserve.md
+++ b/.changeset/quiet-cats-preserve.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-virtual': patch
+---
+
+Preserve measured item sizes when reactive virtualizer options change.

--- a/packages/solid-virtual/package.json
+++ b/packages/solid-virtual/package.json
@@ -26,6 +26,8 @@
     "clean": "premove ./dist ./coverage",
     "test:eslint": "eslint ./src",
     "test:types": "tsc",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"
   },

--- a/packages/solid-virtual/src/index.tsx
+++ b/packages/solid-virtual/src/index.tsx
@@ -81,7 +81,9 @@ function createVirtualizerBase<
         },
       }),
     )
-    virtualizer.measure()
+    virtualizer._willUpdate()
+    setVirtualItems(reconcile(instance.getVirtualItems(), { key: 'index' }))
+    setTotalSize(instance.getTotalSize())
   })
 
   return virtualizer

--- a/packages/solid-virtual/tests/index.test.ts
+++ b/packages/solid-virtual/tests/index.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import { createRoot, createSignal } from 'solid-js'
+
+import { createVirtualizer } from '../src/index'
+
+test('preserves measured sizes when reactive options change', () => {
+  createRoot((dispose) => {
+    const [count, setCount] = createSignal(2)
+    const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
+      get count() {
+        return count()
+      },
+      getScrollElement: () => null,
+      estimateSize: () => 60,
+      initialRect: { width: 800, height: 600 },
+    })
+
+    expect(virtualizer.getTotalSize()).toBe(120)
+    virtualizer.resizeItem(0, 100)
+    expect(virtualizer.getTotalSize()).toBe(160)
+
+    setCount(3)
+
+    expect(virtualizer.itemSizeCache.get(0)).toBe(100)
+    expect(virtualizer.getTotalSize()).toBe(220)
+    dispose()
+  })
+})


### PR DESCRIPTION
## Summary

- replace the Solid adapter's full `measure()` invalidation on reactive option updates with the normal virtualizer update lifecycle
- publish virtual items and total size through Solid without clearing measured item sizes
- add the Solid adapter's first library regression test

This aligns Solid with the lifecycle used by the other adapters:

- React calls `setOptions()` during render and `_willUpdate()` after commit
- Vue calls `setOptions()`, `_willUpdate()`, then `triggerRef()`
- Svelte calls `setOptions()`, `_willUpdate()`, then explicitly publishes its store
- Solid now calls `setOptions()`, `_willUpdate()`, then explicitly publishes its virtual items and total size

The framework publication mechanism differs, but reactive option updates no longer trigger a full measurement invalidation only in Solid.

OpenCode hit this while migrating its long desktop chat timeline from Virtua to TanStack Virtual. Streaming messages, prepended history, and asynchronously resizing tool output require retained visible rows to preserve their measurements; clearing them on a reactive `count` update caused temporary estimated geometry and visible movement.

The regression test measures a row at 100px, reactively increases `count`, and verifies the measurement and resulting total size remain intact.

Fixes #1197

Downstream context: https://github.com/anomalyco/opencode/pull/32331
Downstream patch: https://github.com/anomalyco/opencode/blob/refactor/tanstack-virtual-session/patches/%40tanstack%252Fsolid-virtual%403.13.28.patch

## Verification

- `pnpm --filter @tanstack/solid-virtual test:lib --run`
- `pnpm --filter @tanstack/solid-virtual test:types`
- `pnpm --filter @tanstack/solid-virtual test:eslint`
- `pnpm --filter @tanstack/solid-virtual build`
- Prettier check for changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved measured virtualized item sizes when reactive virtualizer settings change.
  * Improved updates so virtualized item measurements and total size stay in sync after option changes.

* **Tests**
  * Added coverage for reactive updates to confirm previously measured sizes are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->