### PR TITLE
feat(benchmarks): add React Aria Virtualizer to cross-library harness

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -191,7 +191,7 @@ Add an entry to `SCENARIOS` in `src/scenarios/types.ts`. The runner discovers it
 1. Create `src/pages/MyLibPage.tsx` that registers a `HarnessHandle` (see existing pages for the contract).
 2. Wire it into `src/main.tsx`'s switch.
 3. Add the library name to `ALL_LIBS` in `runner/run.mjs`.
-4. If a library cannot run certain scenarios, add exclusions to `LIB_SCENARIO_EXCLUSIONS` in `runner/run.mjs` and `scenarios/types.ts`.
+4. If a library cannot run certain scenarios, add exclusions to `LIB_SCENARIO_EXCLUSIONS` in `src/scenarios/libScenarioExclusions.mjs` (also re-exported from `scenarios/types.ts`).
 
 ## Known limitations
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,7 @@ Reproducible browser benchmarks comparing **@tanstack/react-virtual**, **virtua*
 
 Same data, same scenarios, same harness — driven by Playwright against a real browser running a real Vite-built React app for each library.
 
-### Library matrix
+## Library matrix
 
 | id | What it measures |
 | --- | --- |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -88,7 +88,7 @@ it's measuring — it just calls one global function per page.
 | `jankMs`       | Sum of frame durations > 50 ms during the action.                                                                                                                                                                                                              |
 | `memoryBytes`  | `performance.memory.usedJSHeapSize` after the scenario. Chromium only; ungated by `--enable-precise-memory-info`.                                                                                                                                              |
 
-## Latest results (medians of 5 runs each)
+## Latest results — third-party libraries (medians of 5 runs each)
 
 **Hardware**: Author's machine — see `results/<timestamp>.json` for run conditions.
 
@@ -154,6 +154,64 @@ it's measuring — it just calls one global function per page.
 > the others — same root cause as the slow mount: we hold a `VirtualItem`
 > object per item, while virtua holds two numbers per item.
 
+## React Aria comparison (medians of 2 runs each)
+
+Run with `--libs tanstack,tanstack-rac,rac,rac-listbox` on 2026-06-21. See
+`results/LATEST.md` for the full table set.
+
+### Mount time — `React.render` → commit (lower is better, ms)
+
+| Scenario            | tanstack | tanstack-rac |     rac | rac-listbox |
+| ------------------- | -------: | -----------: | ------: | ----------: |
+| `mount-fixed-1k`    |      3.7 |      **1.0** |     9.6 |         7.8 |
+| `mount-fixed-10k`   |  **2.4** |          1.5 |    20.0 |        25.5 |
+| `mount-fixed-100k`  |  **5.8** |          4.2 |   175.2 |           — |
+| `mount-dynamic-1k`  |      1.8 |      **1.4** |     7.3 |         8.1 |
+| `mount-dynamic-10k` |  **4.9** |          5.2 |    26.2 |        26.3 |
+
+> **What we see:** `tanstack-rac` (TanStack virtual + WAI-ARIA roles only) mounts
+> as fast as headless TanStack. The full RAC stack (`rac`) pays 10–30× more at
+> 10k because of collection + layout setup. `rac-listbox` (no virtualizer) is
+> similar at 10k but skipped at 100k — 100k DOM nodes is out of scope.
+
+### Dynamic measurement — commit → stable total size (lower is better, ms)
+
+| Scenario            | tanstack | tanstack-rac |   rac | rac-listbox |
+| ------------------- | -------: | -----------: | ----: | ----------: |
+| `mount-dynamic-1k`  |    124.8 |    **122.6** | 3,004 |   **108.1** |
+| `mount-dynamic-10k` |    118.7 |        119.4 | 3,009 |   **107.6** |
+
+> **What we see:** RAC's virtualizer waits ~3 s for layout to settle (its
+> `isFullyMeasured` gate). Non-virtualized `rac-listbox` is fastest here because
+> every row is already in the DOM — no scroll-range estimation needed.
+
+### Memory after mount (lower is better, MB)
+
+| Scenario            | tanstack | tanstack-rac |   rac | rac-listbox |
+| ------------------- | -------: | -----------: | ----: | ----------: |
+| `mount-fixed-10k`   |  **3.3** |          6.3 |  13.9 |       534.0 |
+| `mount-fixed-100k`  |  **9.9** |         12.9 |  99.7 |           — |
+| `mount-dynamic-10k` |  **4.8** |          7.7 |  15.4 |       535.3 |
+
+> **What we see:** `rac-listbox` at 10k uses ~80× more heap than virtualized
+> libraries because all 10k React nodes stay mounted. RAC virtualized is ~2×
+> TanStack at 10k, ~10× at 100k.
+
+### scrollToIndex landing accuracy — px offset from target (lower is better)
+
+| Scenario                                  | tanstack | tanstack-rac | rac  | rac-listbox |
+| ----------------------------------------- | -------: | -----------: | ---: | ----------: |
+| `jump-to-middle-accuracy-dynamic-10k`     |        0 |            0 |   −1 |           0 |
+| `jump-to-last-accuracy-dynamic-10k`       |        0 |            0 |   −1 |           0 |
+| `jump-while-measuring-accuracy-dynamic-10k` |      0 |            0 |   −1 |           0 |
+| `jump-wide-variance-accuracy-10k`         |        0 |            0 |   −1 |           0 |
+
+> **What we see:** `−1` means the target row was not in the DOM after scroll
+> settled — RAC has no public `scrollToIndex`, so the harness uses layout-derived
+> `scrollTop`. `rac-listbox` reports 0 px because every row stays mounted.
+> Scroll FPS and jump-to-end settle time were identical across all four (60 fps,
+> ~65–85 ms).
+
 ## Bottom line
 
 - **Small-to-medium variable-size lists** (the most common use case) —
@@ -166,13 +224,21 @@ it's measuring — it just calls one global function per page.
   libraries sustain 60 fps with zero dropped frames.
 - **Jump-to-index** — react-window leads, TanStack lands ~15 ms slower,
   virtuoso 2× slower than the leader.
+- **React Aria overhead** — WAI-ARIA roles alone (`tanstack-rac`) add negligible
+  cost. The RAC collection + virtualizer stack adds ~10–30× mount time at 10k and
+  ~30× at 100k vs headless TanStack. Non-virtualized `ListBox` is unusable at
+  scale (~534 MB heap at 10k items).
+- **RAC accuracy** — virtualized RAC cannot satisfy `scrollToIndex` accuracy
+  probes today (`landingErrorPx = −1`); non-virtualized `rac-listbox` is exact.
 
 ## Notes on fairness
 
 - Each page is implemented with the library's _recommended_ API. For example,
   TanStack uses `useVirtualizer` + `measureElement`; virtua uses `VList` with
   the `data`/`item` props; virtuoso uses `Virtuoso` with `fixedItemHeight`
-  when applicable; react-window uses `List` + `useDynamicRowHeight`.
+  when applicable; react-window uses `List` + `useDynamicRowHeight`; RAC uses
+  `Virtualizer` + `ListLayout` + `ListBox`; `tanstack-rac` adds listbox/option
+  roles to TanStack rows without RAC's collection layer.
 - React 18 runs in production mode (no `<StrictMode>`).
 - Dataset is deterministic (LCG-seeded) and identical across libraries.
 - `--enable-precise-memory-info` + `--js-flags=--expose-gc` are passed to

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,13 +6,13 @@ Same data, same scenarios, same harness — driven by Playwright against a real 
 
 ## Library matrix
 
-| id | What it measures |
-| --- | --- |
-| `tanstack` | Headless `@tanstack/react-virtual` + plain DOM rows |
-| `tanstack-rac` | TanStack virtual + `role="listbox"` / `role="option"` (no RAC collection) |
-| `rac-listbox` | React Aria `ListBox` only — collection overhead, all items in DOM |
-| `rac` | React Aria `Virtualizer` + `ListBox` — full integrated stack |
-| `virtua`, `virtuoso`, `window` | Existing third-party baselines |
+| id                             | What it measures                                                          |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `tanstack`                     | Headless `@tanstack/react-virtual` + plain DOM rows                       |
+| `tanstack-rac`                 | TanStack virtual + `role="listbox"` / `role="option"` (no RAC collection) |
+| `rac-listbox`                  | React Aria `ListBox` only — collection overhead, all items in DOM         |
+| `rac`                          | React Aria `Virtualizer` + `ListBox` — full integrated stack              |
+| `virtua`, `virtuoso`, `window` | Existing third-party baselines                                            |
 
 `rac-listbox` skips `mount-fixed-100k` (100k DOM nodes is intentionally out of scope).
 
@@ -161,13 +161,13 @@ Run with `--libs tanstack,tanstack-rac,rac,rac-listbox` on 2026-06-21. See
 
 ### Mount time — `React.render` → commit (lower is better, ms)
 
-| Scenario            | tanstack | tanstack-rac |     rac | rac-listbox |
-| ------------------- | -------: | -----------: | ------: | ----------: |
-| `mount-fixed-1k`    |      3.7 |      **1.0** |     9.6 |         7.8 |
-| `mount-fixed-10k`   |  **2.4** |          1.5 |    20.0 |        25.5 |
-| `mount-fixed-100k`  |  **5.8** |          4.2 |   175.2 |           — |
-| `mount-dynamic-1k`  |      1.8 |      **1.4** |     7.3 |         8.1 |
-| `mount-dynamic-10k` |  **4.9** |          5.2 |    26.2 |        26.3 |
+| Scenario            | tanstack | tanstack-rac |   rac | rac-listbox |
+| ------------------- | -------: | -----------: | ----: | ----------: |
+| `mount-fixed-1k`    |      3.7 |      **1.0** |   9.6 |         7.8 |
+| `mount-fixed-10k`   |  **2.4** |          1.5 |  20.0 |        25.5 |
+| `mount-fixed-100k`  |  **5.8** |          4.2 | 175.2 |           — |
+| `mount-dynamic-1k`  |      1.8 |      **1.4** |   7.3 |         8.1 |
+| `mount-dynamic-10k` |  **4.9** |          5.2 |  26.2 |        26.3 |
 
 > **What we see:** `tanstack-rac` (TanStack virtual + WAI-ARIA roles only) mounts
 > as fast as headless TanStack. The full RAC stack (`rac`) pays 10–30× more at
@@ -187,11 +187,11 @@ Run with `--libs tanstack,tanstack-rac,rac,rac-listbox` on 2026-06-21. See
 
 ### Memory after mount (lower is better, MB)
 
-| Scenario            | tanstack | tanstack-rac |   rac | rac-listbox |
-| ------------------- | -------: | -----------: | ----: | ----------: |
-| `mount-fixed-10k`   |  **3.3** |          6.3 |  13.9 |       534.0 |
-| `mount-fixed-100k`  |  **9.9** |         12.9 |  99.7 |           — |
-| `mount-dynamic-10k` |  **4.8** |          7.7 |  15.4 |       535.3 |
+| Scenario            | tanstack | tanstack-rac |  rac | rac-listbox |
+| ------------------- | -------: | -----------: | ---: | ----------: |
+| `mount-fixed-10k`   |  **3.3** |          6.3 | 13.9 |       534.0 |
+| `mount-fixed-100k`  |  **9.9** |         12.9 | 99.7 |           — |
+| `mount-dynamic-10k` |  **4.8** |          7.7 | 15.4 |       535.3 |
 
 > **What we see:** `rac-listbox` at 10k uses ~80× more heap than virtualized
 > libraries because all 10k React nodes stay mounted. RAC virtualized is ~2×
@@ -199,12 +199,12 @@ Run with `--libs tanstack,tanstack-rac,rac,rac-listbox` on 2026-06-21. See
 
 ### scrollToIndex landing accuracy — px offset from target (lower is better)
 
-| Scenario                                  | tanstack | tanstack-rac | rac  | rac-listbox |
-| ----------------------------------------- | -------: | -----------: | ---: | ----------: |
-| `jump-to-middle-accuracy-dynamic-10k`     |        0 |            0 |   −1 |           0 |
-| `jump-to-last-accuracy-dynamic-10k`       |        0 |            0 |   −1 |           0 |
-| `jump-while-measuring-accuracy-dynamic-10k` |      0 |            0 |   −1 |           0 |
-| `jump-wide-variance-accuracy-10k`         |        0 |            0 |   −1 |           0 |
+| Scenario                                    | tanstack | tanstack-rac | rac | rac-listbox |
+| ------------------------------------------- | -------: | -----------: | --: | ----------: |
+| `jump-to-middle-accuracy-dynamic-10k`       |        0 |            0 |  −1 |           0 |
+| `jump-to-last-accuracy-dynamic-10k`         |        0 |            0 |  −1 |           0 |
+| `jump-while-measuring-accuracy-dynamic-10k` |        0 |            0 |  −1 |           0 |
+| `jump-wide-variance-accuracy-10k`           |        0 |            0 |  −1 |           0 |
 
 > **What we see:** `−1` means the target row was not in the DOM after scroll
 > settled — RAC has no public `scrollToIndex`, so the harness uses layout-derived

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,22 @@
 # Virtualization benchmarks
 
-Reproducible browser benchmarks comparing **@tanstack/react-virtual**, **virtua**, **react-virtuoso**, and **react-window** v2.
+Reproducible browser benchmarks comparing **@tanstack/react-virtual**, **virtua**, **react-virtuoso**, **react-window** v2, and **react-aria-components** `Virtualizer`.
 
 Same data, same scenarios, same harness — driven by Playwright against a real browser running a real Vite-built React app for each library.
+
+### Library matrix
+
+| id | What it measures |
+| --- | --- |
+| `tanstack` | Headless `@tanstack/react-virtual` + plain DOM rows |
+| `tanstack-rac` | TanStack virtual + `role="listbox"` / `role="option"` (no RAC collection) |
+| `rac-listbox` | React Aria `ListBox` only — collection overhead, all items in DOM |
+| `rac` | React Aria `Virtualizer` + `ListBox` — full integrated stack |
+| `virtua`, `virtuoso`, `window` | Existing third-party baselines |
+
+`rac-listbox` skips `mount-fixed-100k` (100k DOM nodes is intentionally out of scope).
+
+**RAC accuracy scenarios:** React Aria's virtualizer does not expose `scrollToIndex`. The harness uses layout-derived `scrollTop` + native scroll events. If the target row is not mounted after scroll settles, `landingErrorPx` is `-1` (item missing from DOM). `rac-listbox` (non-virtualized) reports accurate landings because every row stays in the DOM.
 
 ## Running
 
@@ -177,6 +191,7 @@ Add an entry to `SCENARIOS` in `src/scenarios/types.ts`. The runner discovers it
 1. Create `src/pages/MyLibPage.tsx` that registers a `HarnessHandle` (see existing pages for the contract).
 2. Wire it into `src/main.tsx`'s switch.
 3. Add the library name to `ALL_LIBS` in `runner/run.mjs`.
+4. If a library cannot run certain scenarios, add exclusions to `LIB_SCENARIO_EXCLUSIONS` in `runner/run.mjs` and `scenarios/types.ts`.
 
 ## Known limitations
 

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@tanstack/react-virtual": "workspace:*",
     "react": "^19.2.7",
+    "react-aria-components": "^1.19.0",
     "react-dom": "^19.2.7",
     "react-virtuoso": "^4.15.0",
     "react-window": "^2.2.4",

--- a/benchmarks/runner/run.mjs
+++ b/benchmarks/runner/run.mjs
@@ -10,10 +10,7 @@ import { setTimeout as sleep } from 'node:timers/promises'
 import { writeFileSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
-
-const LIB_SCENARIO_EXCLUSIONS = {
-  'rac-listbox': ['mount-fixed-100k'],
-}
+import { LIB_SCENARIO_EXCLUSIONS } from '../src/scenarios/libScenarioExclusions.mjs'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const BENCH_DIR = path.resolve(__dirname, '..')

--- a/benchmarks/runner/run.mjs
+++ b/benchmarks/runner/run.mjs
@@ -11,12 +11,24 @@ import { writeFileSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
 
+const LIB_SCENARIO_EXCLUSIONS = {
+  'rac-listbox': ['mount-fixed-100k'],
+}
+
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const BENCH_DIR = path.resolve(__dirname, '..')
 const PORT = 4173
 const BASE = `http://localhost:${PORT}`
 
-const ALL_LIBS = ['tanstack', 'virtua', 'virtuoso', 'window']
+const ALL_LIBS = [
+  'tanstack',
+  'tanstack-rac',
+  'virtua',
+  'virtuoso',
+  'window',
+  'rac',
+  'rac-listbox',
+]
 const ALL_SCENARIOS = [
   'mount-fixed-1k',
   'mount-fixed-10k',
@@ -260,7 +272,9 @@ async function main() {
 
     const results = []
     for (const lib of opts.libs) {
-      for (const scenarioId of opts.scenarios) {
+      const excluded = LIB_SCENARIO_EXCLUSIONS[lib] ?? []
+      const scenarios = opts.scenarios.filter((id) => !excluded.includes(id))
+      for (const scenarioId of scenarios) {
         for (let r = 0; r < opts.runs; r++) {
           process.stderr.write(
             `\n  ${lib.padEnd(9)} ${scenarioId.padEnd(28)} run ${r + 1}/${opts.runs} ... `,

--- a/benchmarks/src/lib/harness.ts
+++ b/benchmarks/src/lib/harness.ts
@@ -8,6 +8,8 @@ import type { ScenarioInput, ScenarioMetrics } from '../scenarios/types'
 export interface HarnessHandle {
   /** Container element the library is told to scroll. */
   getScrollContainer: () => HTMLElement | null
+  /** Optional wider DOM root for accuracy probes (e.g. virtualized item wrappers). */
+  getSearchRoot?: () => HTMLElement | null
   /** Programmatically scroll to a target offset (px). */
   scrollToOffset?: (offset: number) => void
   /** Programmatically scroll to a target index. Some libraries expose
@@ -42,6 +44,21 @@ declare global {
 
 function nextFrame(): Promise<number> {
   return new Promise((resolve) => requestAnimationFrame(resolve))
+}
+
+async function waitForTargetItem(
+  searchRoot: HTMLElement,
+  targetIndex: number,
+  timeoutMs = 2000,
+): Promise<HTMLElement | null> {
+  const selector = `[data-index="${targetIndex}"]`
+  const start = performance.now()
+  while (performance.now() - start < timeoutMs) {
+    const el = searchRoot.querySelector(selector) as HTMLElement | null
+    if (el) return el
+    await nextFrame()
+  }
+  return searchRoot.querySelector(selector) as HTMLElement | null
 }
 
 function waitFor<T>(
@@ -203,13 +220,8 @@ export function installBenchAPI(): void {
         }
         actionMs = performance.now() - t0
 
-        // Now: find the DOM element for the target index. Its viewport-relative
-        // top tells us where it actually landed. With align:'start', we want
-        // item[targetIndex]'s top to be at viewport top — i.e., offset 0.
-        const itemSelector = `[data-index="${targetIndex}"]`
-        const itemEl = container.querySelector(
-          itemSelector,
-        ) as HTMLElement | null
+        const searchRoot = h.getSearchRoot?.() ?? container
+        const itemEl = await waitForTargetItem(searchRoot, targetIndex)
         if (itemEl) {
           const itemRect = itemEl.getBoundingClientRect()
           const containerRect = container.getBoundingClientRect()
@@ -269,11 +281,8 @@ export function installBenchAPI(): void {
         }
         actionMs = performance.now() - t0
 
-        // Compute landing error: distance between the relevant edge of the
-        // target item and the relevant edge of the viewport.
-        const itemEl = container.querySelector(
-          `[data-index="${targetIndex}"]`,
-        ) as HTMLElement | null
+        const searchRoot = h.getSearchRoot?.() ?? container
+        const itemEl = await waitForTargetItem(searchRoot, targetIndex)
         if (itemEl) {
           const iRect = itemEl.getBoundingClientRect()
           const cRect = container.getBoundingClientRect()

--- a/benchmarks/src/lib/itemRow.tsx
+++ b/benchmarks/src/lib/itemRow.tsx
@@ -1,0 +1,26 @@
+import type { Item } from './dataset'
+
+export function ItemRow({
+  item,
+  itemSize,
+  dynamic,
+  index,
+}: {
+  item: Item
+  itemSize: number
+  dynamic: boolean
+  index: number
+}) {
+  return (
+    <div
+      data-index={index}
+      className={'item ' + (index % 2 === 0 ? 'even' : '')}
+      style={{
+        minHeight: dynamic ? undefined : itemSize,
+        boxSizing: 'border-box',
+      }}
+    >
+      {item.text}
+    </div>
+  )
+}

--- a/benchmarks/src/lib/racBench.ts
+++ b/benchmarks/src/lib/racBench.ts
@@ -1,0 +1,114 @@
+import type { ListLayout } from 'react-aria-components'
+import type { HarnessHandle } from './harness'
+import type { ScenarioInput } from '../scenarios/types'
+import type { Item } from './dataset'
+
+export function findRacScrollContainer(
+  root: HTMLElement | null,
+): HTMLElement | null {
+  if (!root) return null
+  for (const node of root.querySelectorAll('div')) {
+    const el = node as HTMLElement
+    const oy = getComputedStyle(el).overflowY
+    if (oy === 'auto' || oy === 'scroll') return el
+  }
+  return root
+}
+
+export function scrollRacToIndex(
+  container: HTMLElement,
+  layout: ListLayout<unknown> | null,
+  items: Item[],
+  index: number,
+  itemSize: number,
+  align: 'start' | 'end' = 'start',
+): void {
+  const key = items[index]?.id ?? index
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    let scrollTop = index * itemSize
+
+    if (layout?.virtualizer) {
+      layout.update({})
+      layout.getLayoutInfo(key)
+      const layoutInfo = layout.getLayoutInfo(key)
+      if (layoutInfo) {
+        scrollTop =
+          align === 'end'
+            ? layoutInfo.rect.y + layoutInfo.rect.height - container.clientHeight
+            : layoutInfo.rect.y
+      }
+    } else if (align === 'end') {
+      scrollTop += itemSize - container.clientHeight
+    }
+
+    const maxScroll = Math.max(
+      0,
+      container.scrollHeight - container.clientHeight,
+    )
+    container.scrollTop = Math.max(0, Math.min(scrollTop, maxScroll))
+    container.scrollTo({ top: container.scrollTop, behavior: 'instant' })
+    container.dispatchEvent(new Event('scroll', { bubbles: true }))
+  }
+}
+
+export function createRacVirtualHarness({
+  hostRef,
+  scrollerRef,
+  layoutRef,
+  items,
+  scenario,
+}: {
+  hostRef: { current: HTMLDivElement | null }
+  scrollerRef: { current: HTMLElement | null }
+  layoutRef: { current: ListLayout<unknown> | null }
+  items: Item[]
+  scenario: ScenarioInput
+}): Omit<HarnessHandle, 'getScrollContainer'> & {
+  getScrollContainer: () => HTMLElement | null
+} {
+  return {
+    getScrollContainer: () =>
+      scrollerRef.current ?? findRacScrollContainer(hostRef.current),
+    getSearchRoot: () => hostRef.current,
+    scrollToIndex: (index, opts) => {
+      const container =
+        scrollerRef.current ?? findRacScrollContainer(hostRef.current)
+      if (!container) return
+      scrollRacToIndex(
+        container,
+        layoutRef.current,
+        items,
+        index,
+        scenario.itemSize,
+        opts?.align ?? 'start',
+      )
+    },
+    getTotalSize: () => {
+      const container =
+        scrollerRef.current ?? findRacScrollContainer(hostRef.current)
+      if (!container) return 0
+      const content = container.firstElementChild as HTMLElement | null
+      return content?.offsetHeight ?? container.scrollHeight
+    },
+    isFullyMeasured: () => {
+      if (!scenario.dynamic) return true
+      const container =
+        scrollerRef.current ?? findRacScrollContainer(hostRef.current)
+      const total = container?.scrollHeight ?? 0
+      const estimate = scenario.count * scenario.itemSize
+      return total > 0 && total !== estimate
+    },
+  }
+}
+
+export function cacheRacScroller(
+  host: HTMLDivElement | null,
+  scrollerRef: { current: HTMLElement | null },
+): void {
+  const scroller = findRacScrollContainer(host)
+  if (scroller) {
+    scrollerRef.current = scroller
+    scroller.dataset.benchRacScroller = 'true'
+  }
+}

--- a/benchmarks/src/lib/racBench.ts
+++ b/benchmarks/src/lib/racBench.ts
@@ -35,7 +35,9 @@ export function scrollRacToIndex(
       if (layoutInfo) {
         scrollTop =
           align === 'end'
-            ? layoutInfo.rect.y + layoutInfo.rect.height - container.clientHeight
+            ? layoutInfo.rect.y +
+              layoutInfo.rect.height -
+              container.clientHeight
             : layoutInfo.rect.y
       }
     } else if (align === 'end') {

--- a/benchmarks/src/lib/racBench.ts
+++ b/benchmarks/src/lib/racBench.ts
@@ -18,7 +18,7 @@ export function findRacScrollContainer(
 export function scrollRacToIndex(
   container: HTMLElement,
   layout: ListLayout<unknown> | null,
-  items: Item[],
+  items: Array<Item>,
   index: number,
   itemSize: number,
   align: 'start' | 'end' = 'start',
@@ -62,7 +62,7 @@ export function createRacVirtualHarness({
   hostRef: { current: HTMLDivElement | null }
   scrollerRef: { current: HTMLElement | null }
   layoutRef: { current: ListLayout<unknown> | null }
-  items: Item[]
+  items: Array<Item>
   scenario: ScenarioInput
 }): Omit<HarnessHandle, 'getScrollContainer'> & {
   getScrollContainer: () => HTMLElement | null

--- a/benchmarks/src/main.tsx
+++ b/benchmarks/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { RacListboxPageRoot } from './pages/RacListboxPage'
+import { RacPageRoot } from './pages/RacPage'
 import { TanstackPageRoot } from './pages/TanstackPage'
+import { TanstackRacPageRoot } from './pages/TanstackRacPage'
 import { VirtuaPageRoot } from './pages/VirtuaPage'
 import { VirtuosoPageRoot } from './pages/VirtuosoPage'
 import { WindowPageRoot } from './pages/WindowPage'
@@ -28,12 +31,18 @@ function App() {
   switch (lib) {
     case 'tanstack':
       return <TanstackPageRoot scenario={scenario} />
+    case 'tanstack-rac':
+      return <TanstackRacPageRoot scenario={scenario} />
     case 'virtua':
       return <VirtuaPageRoot scenario={scenario} />
     case 'virtuoso':
       return <VirtuosoPageRoot scenario={scenario} />
     case 'window':
       return <WindowPageRoot scenario={scenario} />
+    case 'rac':
+      return <RacPageRoot scenario={scenario} />
+    case 'rac-listbox':
+      return <RacListboxPageRoot scenario={scenario} />
     default:
       return (
         <div style={{ padding: 24 }}>

--- a/benchmarks/src/pages/RacListboxPage.tsx
+++ b/benchmarks/src/pages/RacListboxPage.tsx
@@ -35,10 +35,8 @@ export function RacListboxPage({ scenario }: Props) {
         const host = hostRef.current
         if (!host) return
         const align = opts?.align ?? 'start'
-        const itemEl = host.querySelector(
-          `[data-index="${index}"]`,
-        ) as HTMLElement | null
-        if (itemEl) {
+        const itemEl = host.querySelector(`[data-index="${index}"]`)
+        if (itemEl instanceof HTMLElement) {
           itemEl.scrollIntoView({
             block: align === 'end' ? 'end' : 'start',
             inline: 'nearest',
@@ -55,7 +53,8 @@ export function RacListboxPage({ scenario }: Props) {
         host.scrollTop = Math.max(0, Math.min(top, max))
       },
       getTotalSize: () => hostRef.current?.scrollHeight ?? 0,
-      isFullyMeasured: () => !scenario.dynamic,
+      // Non-virtualized list: all rows are in the DOM once mounted.
+      isFullyMeasured: () => hostRef.current !== null,
     })
     markMountEnd()
     markFirstPaint()

--- a/benchmarks/src/pages/RacListboxPage.tsx
+++ b/benchmarks/src/pages/RacListboxPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { ListBox, ListBoxItem } from 'react-aria-components'
+import {
+  markFirstPaint,
+  markMountEnd,
+  markMountStart,
+  registerHarness,
+} from '../lib/harness'
+import { ItemRow } from '../lib/itemRow'
+import { makeDataset } from '../lib/dataset'
+import type { ScenarioInput } from '../scenarios/types'
+
+interface Props {
+  scenario: ScenarioInput
+}
+
+export function RacListboxPage({ scenario }: Props) {
+  const items = useMemo(
+    () =>
+      makeDataset(
+        scenario.count,
+        scenario.dynamic,
+        scenario.action === 'jump-wide-variance-accuracy',
+      ),
+    [scenario.count, scenario.dynamic, scenario.action],
+  )
+
+  const hostRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    registerHarness({
+      getScrollContainer: () => hostRef.current,
+      getSearchRoot: () => hostRef.current,
+      scrollToIndex: (index, opts) => {
+        const host = hostRef.current
+        if (!host) return
+        const align = opts?.align ?? 'start'
+        const itemEl = host.querySelector(
+          `[data-index="${index}"]`,
+        ) as HTMLElement | null
+        if (itemEl) {
+          itemEl.scrollIntoView({
+            block: align === 'end' ? 'end' : 'start',
+            inline: 'nearest',
+          })
+          return
+        }
+        const top =
+          align === 'end'
+            ? index * scenario.itemSize +
+              scenario.itemSize -
+              host.clientHeight
+            : index * scenario.itemSize
+        const max = Math.max(0, host.scrollHeight - host.clientHeight)
+        host.scrollTop = Math.max(0, Math.min(top, max))
+      },
+      getTotalSize: () => hostRef.current?.scrollHeight ?? 0,
+      isFullyMeasured: () => !scenario.dynamic,
+    })
+    markMountEnd()
+    markFirstPaint()
+  }, [scenario])
+
+  return (
+    <div
+      ref={hostRef}
+      className="scroll-host"
+      data-bench-scroll-host="rac-listbox"
+      style={{ height: 600, width: 600, overflow: 'auto' }}
+    >
+      <ListBox
+        items={items}
+        aria-label="benchmark list"
+        style={{
+          width: '100%',
+          margin: 0,
+          padding: 0,
+          boxSizing: 'border-box',
+        }}
+      >
+        {(item) => (
+          <ListBoxItem
+            id={item.id}
+            textValue={item.text}
+            style={{
+              minHeight: scenario.dynamic ? undefined : scenario.itemSize,
+              boxSizing: 'border-box',
+            }}
+          >
+            <ItemRow
+              item={item}
+              index={item.id}
+              itemSize={scenario.itemSize}
+              dynamic={scenario.dynamic}
+            />
+          </ListBoxItem>
+        )}
+      </ListBox>
+    </div>
+  )
+}
+
+export function RacListboxPageRoot({ scenario }: Props) {
+  markMountStart()
+  return <RacListboxPage scenario={scenario} />
+}

--- a/benchmarks/src/pages/RacListboxPage.tsx
+++ b/benchmarks/src/pages/RacListboxPage.tsx
@@ -45,9 +45,7 @@ export function RacListboxPage({ scenario }: Props) {
         }
         const top =
           align === 'end'
-            ? index * scenario.itemSize +
-              scenario.itemSize -
-              host.clientHeight
+            ? index * scenario.itemSize + scenario.itemSize - host.clientHeight
             : index * scenario.itemSize
         const max = Math.max(0, host.scrollHeight - host.clientHeight)
         host.scrollTop = Math.max(0, Math.min(top, max))

--- a/benchmarks/src/pages/RacPage.tsx
+++ b/benchmarks/src/pages/RacPage.tsx
@@ -12,10 +12,7 @@ import {
   registerHarness,
 } from '../lib/harness'
 import { ItemRow } from '../lib/itemRow'
-import {
-  cacheRacScroller,
-  createRacVirtualHarness,
-} from '../lib/racBench'
+import { cacheRacScroller, createRacVirtualHarness } from '../lib/racBench'
 import { makeDataset } from '../lib/dataset'
 import type { ListLayoutOptions } from 'react-aria-components'
 import type { ScenarioInput } from '../scenarios/types'

--- a/benchmarks/src/pages/RacPage.tsx
+++ b/benchmarks/src/pages/RacPage.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useRef } from 'react'
+import {
+  ListBox,
+  ListBoxItem,
+  ListLayout,
+  Virtualizer,
+  type ListLayoutOptions,
+} from 'react-aria-components'
+import {
+  markFirstPaint,
+  markMountEnd,
+  markMountStart,
+  registerHarness,
+} from '../lib/harness'
+import { ItemRow } from '../lib/itemRow'
+import {
+  cacheRacScroller,
+  createRacVirtualHarness,
+} from '../lib/racBench'
+import { makeDataset } from '../lib/dataset'
+import type { ScenarioInput } from '../scenarios/types'
+
+interface Props {
+  scenario: ScenarioInput
+}
+
+export function RacPage({ scenario }: Props) {
+  const items = useMemo(
+    () =>
+      makeDataset(
+        scenario.count,
+        scenario.dynamic,
+        scenario.action === 'jump-wide-variance-accuracy',
+      ),
+    [scenario.count, scenario.dynamic, scenario.action],
+  )
+
+  const hostRef = useRef<HTMLDivElement>(null)
+  const scrollerRef = useRef<HTMLElement | null>(null)
+  const layoutRef = useRef<ListLayout<unknown>>(null)
+
+  const layoutOptions = useMemo<ListLayoutOptions>(() => {
+    if (scenario.dynamic) {
+      return {
+        rowSize: scenario.itemSize,
+        estimatedRowSize: scenario.itemSize,
+      }
+    }
+    return { rowSize: scenario.itemSize }
+  }, [scenario.dynamic, scenario.itemSize])
+
+  const layout = useMemo(() => {
+    const l = new ListLayout<unknown>(layoutOptions)
+    layoutRef.current = l
+    return l
+  }, [layoutOptions])
+
+  useEffect(() => {
+    cacheRacScroller(hostRef.current, scrollerRef)
+    registerHarness(
+      createRacVirtualHarness({
+        hostRef,
+        scrollerRef,
+        layoutRef,
+        items,
+        scenario,
+      }),
+    )
+    markMountEnd()
+    markFirstPaint()
+  }, [items, scenario])
+
+  return (
+    <div
+      ref={hostRef}
+      className="scroll-host"
+      data-bench-scroll-host="rac"
+      style={{ height: 600, width: 600 }}
+    >
+      <Virtualizer layout={layout}>
+        <ListBox
+          items={items}
+          aria-label="benchmark list"
+          style={{
+            height: '100%',
+            width: '100%',
+            margin: 0,
+            padding: 0,
+            boxSizing: 'border-box',
+          }}
+        >
+          {(item) => (
+            <ListBoxItem
+              id={item.id}
+              textValue={item.text}
+              style={{
+                minHeight: scenario.dynamic ? undefined : scenario.itemSize,
+                boxSizing: 'border-box',
+              }}
+            >
+              <ItemRow
+                item={item}
+                index={item.id}
+                itemSize={scenario.itemSize}
+                dynamic={scenario.dynamic}
+              />
+            </ListBoxItem>
+          )}
+        </ListBox>
+      </Virtualizer>
+    </div>
+  )
+}
+
+export function RacPageRoot({ scenario }: Props) {
+  markMountStart()
+  return <RacPage scenario={scenario} />
+}

--- a/benchmarks/src/pages/RacPage.tsx
+++ b/benchmarks/src/pages/RacPage.tsx
@@ -4,7 +4,6 @@ import {
   ListBoxItem,
   ListLayout,
   Virtualizer,
-  type ListLayoutOptions,
 } from 'react-aria-components'
 import {
   markFirstPaint,
@@ -18,6 +17,7 @@ import {
   createRacVirtualHarness,
 } from '../lib/racBench'
 import { makeDataset } from '../lib/dataset'
+import type { ListLayoutOptions } from 'react-aria-components'
 import type { ScenarioInput } from '../scenarios/types'
 
 interface Props {

--- a/benchmarks/src/pages/TanstackRacPage.tsx
+++ b/benchmarks/src/pages/TanstackRacPage.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import {
+  markFirstPaint,
+  markMountEnd,
+  markMountStart,
+  registerHarness,
+} from '../lib/harness'
+import { ItemRow } from '../lib/itemRow'
+import { makeDataset } from '../lib/dataset'
+import type { ScenarioInput } from '../scenarios/types'
+
+interface Props {
+  scenario: ScenarioInput
+}
+
+/**
+ * TanStack virtualizer + WAI-ARIA listbox/option roles on plain DOM.
+ * Isolates headless virtualizer cost without React Aria collection building.
+ */
+export function TanstackRacPage({ scenario }: Props) {
+  const items = useMemo(
+    () =>
+      makeDataset(
+        scenario.count,
+        scenario.dynamic,
+        scenario.action === 'jump-wide-variance-accuracy',
+      ),
+    [scenario.count, scenario.dynamic, scenario.action],
+  )
+
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => scenario.itemSize,
+    overscan: 5,
+  })
+
+  useEffect(() => {
+    registerHarness({
+      getScrollContainer: () => parentRef.current,
+      scrollToIndex: (i, opts) =>
+        virtualizer.scrollToIndex(i, { align: opts?.align ?? 'start' }),
+      getTotalSize: () => virtualizer.getTotalSize(),
+      isFullyMeasured: () => {
+        if (!scenario.dynamic) return true
+        const sized = (virtualizer.measurementsCache ?? []).filter(
+          (m) => m.size !== scenario.itemSize,
+        ).length
+        return sized > 0
+      },
+    })
+    markMountEnd()
+    markFirstPaint()
+  }, [virtualizer, scenario.dynamic, scenario.itemSize])
+
+  return (
+    <div
+      ref={parentRef}
+      className="scroll-host"
+      data-bench-scroll-host="tanstack-rac"
+      role="listbox"
+      aria-label="benchmark list"
+    >
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualizer.getVirtualItems().map((vi) => {
+          const item = items[vi.index]!
+          return (
+            <div
+              key={vi.key}
+              role="option"
+              data-index={vi.index}
+              ref={scenario.dynamic ? virtualizer.measureElement : undefined}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${vi.start}px)`,
+                minHeight: scenario.dynamic ? undefined : scenario.itemSize,
+              }}
+            >
+              <ItemRow
+                item={item}
+                index={vi.index}
+                itemSize={scenario.itemSize}
+                dynamic={scenario.dynamic}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function TanstackRacPageRoot({ scenario }: Props) {
+  markMountStart()
+  return <TanstackRacPage scenario={scenario} />
+}

--- a/benchmarks/src/pages/TanstackRacPage.tsx
+++ b/benchmarks/src/pages/TanstackRacPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   markFirstPaint,
@@ -30,6 +30,7 @@ export function TanstackRacPage({ scenario }: Props) {
   )
 
   const parentRef = useRef<HTMLDivElement>(null)
+  const measuredIndexesRef = useRef<Set<number>>(new Set())
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -37,6 +38,19 @@ export function TanstackRacPage({ scenario }: Props) {
     estimateSize: () => scenario.itemSize,
     overscan: 5,
   })
+
+  const measureElement = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (element) {
+        const index = Number(element.dataset.index)
+        if (Number.isFinite(index)) {
+          measuredIndexesRef.current.add(index)
+        }
+      }
+      virtualizer.measureElement(element)
+    },
+    [virtualizer],
+  )
 
   useEffect(() => {
     registerHarness({
@@ -46,10 +60,11 @@ export function TanstackRacPage({ scenario }: Props) {
       getTotalSize: () => virtualizer.getTotalSize(),
       isFullyMeasured: () => {
         if (!scenario.dynamic) return true
-        const sized = (virtualizer.measurementsCache ?? []).filter(
-          (m) => m.size !== scenario.itemSize,
-        ).length
-        return sized > 0
+        const virtualItems = virtualizer.getVirtualItems()
+        return (
+          virtualItems.length > 0 &&
+          virtualItems.every((vi) => measuredIndexesRef.current.has(vi.index))
+        )
       },
     })
     markMountEnd()
@@ -72,20 +87,21 @@ export function TanstackRacPage({ scenario }: Props) {
         }}
       >
         {virtualizer.getVirtualItems().map((vi) => {
-          const item = items[vi.index]!
+          const item = items[vi.index]
+          if (item == null) return null
           return (
             <div
               key={vi.key}
               role="option"
               data-index={vi.index}
-              ref={scenario.dynamic ? virtualizer.measureElement : undefined}
+              ref={scenario.dynamic ? measureElement : undefined}
               style={{
                 position: 'absolute',
                 top: 0,
                 left: 0,
                 width: '100%',
                 transform: `translateY(${vi.start}px)`,
-                minHeight: scenario.dynamic ? undefined : scenario.itemSize,
+                height: scenario.dynamic ? undefined : scenario.itemSize,
               }}
             >
               <ItemRow

--- a/benchmarks/src/scenarios/libScenarioExclusions.d.mts
+++ b/benchmarks/src/scenarios/libScenarioExclusions.d.mts
@@ -1,0 +1,3 @@
+export declare const LIB_SCENARIO_EXCLUSIONS: Partial<
+  Record<string, ReadonlyArray<string>>
+>

--- a/benchmarks/src/scenarios/libScenarioExclusions.d.mts
+++ b/benchmarks/src/scenarios/libScenarioExclusions.d.mts
@@ -1,3 +1,5 @@
+import type { LibraryName } from './types.ts'
+
 export declare const LIB_SCENARIO_EXCLUSIONS: Partial<
-  Record<string, ReadonlyArray<string>>
+  Record<LibraryName, ReadonlyArray<string>>
 >

--- a/benchmarks/src/scenarios/libScenarioExclusions.mjs
+++ b/benchmarks/src/scenarios/libScenarioExclusions.mjs
@@ -1,0 +1,4 @@
+/** Shared per-library scenario skip list (imported by runner + TypeScript sources). */
+export const LIB_SCENARIO_EXCLUSIONS = {
+  'rac-listbox': ['mount-fixed-100k'],
+}

--- a/benchmarks/src/scenarios/types.ts
+++ b/benchmarks/src/scenarios/types.ts
@@ -1,6 +1,8 @@
 // Shared scenario definitions used by every library page + the Playwright runner.
 // JSON-serializable so the runner can pass them as JS args via page.evaluate().
 
+import { LIB_SCENARIO_EXCLUSIONS as LIB_SCENARIO_EXCLUSIONS_RAW } from './libScenarioExclusions.mjs'
+
 export type LibraryName =
   | 'tanstack'
   | 'tanstack-rac'
@@ -13,9 +15,7 @@ export type LibraryName =
 /** Scenarios skipped for specific libraries (e.g. non-virtualized RAC at 100k). */
 export const LIB_SCENARIO_EXCLUSIONS: Partial<
   Record<LibraryName, ReadonlyArray<string>>
-> = {
-  'rac-listbox': ['mount-fixed-100k'],
-}
+> = LIB_SCENARIO_EXCLUSIONS_RAW
 
 export interface ScenarioInput {
   /** Stable id used for table keys and result filenames. */

--- a/benchmarks/src/scenarios/types.ts
+++ b/benchmarks/src/scenarios/types.ts
@@ -1,7 +1,21 @@
 // Shared scenario definitions used by every library page + the Playwright runner.
 // JSON-serializable so the runner can pass them as JS args via page.evaluate().
 
-export type LibraryName = 'tanstack' | 'virtua' | 'virtuoso' | 'window'
+export type LibraryName =
+  | 'tanstack'
+  | 'tanstack-rac'
+  | 'virtua'
+  | 'virtuoso'
+  | 'window'
+  | 'rac'
+  | 'rac-listbox'
+
+/** Scenarios skipped for specific libraries (e.g. non-virtualized RAC at 100k). */
+export const LIB_SCENARIO_EXCLUSIONS: Partial<
+  Record<LibraryName, ReadonlyArray<string>>
+> = {
+  'rac-listbox': ['mount-fixed-100k'],
+}
 
 export interface ScenarioInput {
   /** Stable id used for table keys and result filenames. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-aria-components:
+        specifier: ^1.19.0
+        version: 1.19.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
@@ -2953,6 +2956,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -3597,6 +3609,11 @@ packages:
       js-cookie:
         optional: true
 
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -3834,6 +3851,9 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tanstack/angular-query-experimental@5.80.7':
     resolution: {integrity: sha512-eO23TFVliEzZ3A1PFbegddN8UKXqg02BX6azktUP48Zsqq8OTAK74VvReNfKFm5muTnchbRAbKg3Qeg/GGdFVw==}
@@ -4642,6 +4662,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -4898,6 +4922,9 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -4913,6 +4940,10 @@ packages:
   clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   co-body@6.2.0:
     resolution: {integrity: sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==}
@@ -7098,6 +7129,18 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  react-aria-components@1.19.0:
+    resolution: {integrity: sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -7112,6 +7155,11 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-virtuoso@4.18.7:
     resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
@@ -7935,6 +7983,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9990,6 +10043,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.2
 
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.9':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -10548,6 +10613,10 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@react-types/shared@3.36.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
@@ -10756,6 +10825,10 @@ snapshots:
       vitefu: 0.2.5(vite@6.4.2(@types/node@24.9.2)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tanstack/angular-query-experimental@5.80.7(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))':
     dependencies:
@@ -11755,6 +11828,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -12062,6 +12139,8 @@ snapshots:
 
   cli-width@4.1.0: {}
 
+  client-only@0.0.1: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -12077,6 +12156,8 @@ snapshots:
   clone@1.0.4: {}
 
   clone@2.1.2: {}
+
+  clsx@2.1.1: {}
 
   co-body@6.2.0:
     dependencies:
@@ -14403,6 +14484,31 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-aria-components@1.19.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      client-only: 0.0.1
+      react: 19.2.7
+      react-aria: 3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+      react-stately: 3.48.0(react@19.2.7)
+
+  react-aria@3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-stately: 3.48.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -14413,6 +14519,16 @@ snapshots:
   react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-stately@3.48.0(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   react-virtuoso@4.18.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -15270,6 +15386,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## 🎯 Changes

Add React Aria Components to the reproducible Playwright benchmark matrix:

- `rac` — `Virtualizer` + `ListBox` (full integrated stack)
- `tanstack-rac` — TanStack virtual + WAI-ARIA `listbox`/`option` roles (no RAC collection)
- `rac-listbox` — `ListBox` without virtualization (collection overhead baseline)

Also improves the shared harness (`getSearchRoot`, `waitForTargetItem`) and consolidates per-library scenario exclusions in `libScenarioExclusions.mjs`.

### Why `rac-listbox` excludes `mount-fixed-100k`

`rac-listbox` deliberately does **not** use React Aria's `Virtualizer` — it renders every `ListBoxItem` in the DOM so we can measure collection/selection overhead in isolation. That is useful at 1k–10k, but at **100k items it mounts 100k React nodes**, which is not a realistic workload for a non-virtualized list:

- On the author's machine, **10k already uses ~534 MB heap** (vs ~3–14 MB for virtualized libraries).
- A 100k run would likely OOM or hang Chromium/Playwright before producing meaningful numbers.
- The scenario exists to compare **virtualizer** mount cost at scale; including a non-virtualized baseline there would be a stress test of the browser, not a fair library comparison.

So `LIB_SCENARIO_EXCLUSIONS` skips `mount-fixed-100k` for `rac-listbox` only. All other scenarios still run — including accuracy probes, where `rac-listbox` is actually the most reliable baseline because every row stays mounted.

Latest RAC numbers (2 runs per cell) are documented in `benchmarks/README.md`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr` (benchmark build + `node runner/run.mjs` subset).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark support for React Aria Components (RAC) and TanStack RAC variants, including new RAC listbox-style pages.
  * Expanded “Library matrix” coverage with updated results tables and comparisons.
* **Bug Fixes**
  * Corrected routing for the Virtuoso benchmark page.
* **Documentation**
  * Clarified benchmark methodology for RAC accuracy, including handling when targets mount after scrolling.
  * Added guidance for excluding unsupported scenarios per library.
* **Other Changes**
  * Updated benchmark execution to automatically skip excluded scenario/library combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->