### PR TITLE
perf(virtual-core): drop closures from `calculateRange` on the `lanes===1` hot path

### DIFF
--- a/.changeset/calculate-range-fewer-allocs.md
+++ b/.changeset/calculate-range-fewer-allocs.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Cut per-scroll-frame allocations on the default `lanes === 1` path. Range computation previously allocated an options object and two closures on every scroll event; it now does the same work allocation-free, reducing GC pressure during continuous scroll.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1334,22 +1334,22 @@ export class Virtualizer<
       this.options.lanes,
     ],
     (measurements, outerSize, scrollOffset, lanes) => {
-      return (this.range =
-        measurements.length > 0 && outerSize > 0
-          ? calculateRange({
-              measurements,
-              outerSize,
-              scrollOffset,
-              lanes,
-              // Pass the typed array so binary search + forward-walk can
-              // read start/end directly from Float64Array, skipping the
-              // Proxy traps that materialize a full VirtualItem per probe.
-              flat:
-                lanes === 1 && this._flatMeasurements != null
-                  ? this._flatMeasurements
-                  : null,
-            })
-          : null)
+      if (measurements.length === 0 || outerSize === 0) {
+        this.range = null
+        return null
+      }
+      this.range = calculateRangeImpl(
+        measurements,
+        outerSize,
+        scrollOffset,
+        lanes,
+        // Pass the typed array so binary search + forward-walk can read
+        // start/end directly from Float64Array, skipping the Proxy traps.
+        lanes === 1 && this._flatMeasurements != null
+          ? this._flatMeasurements
+          : null,
+      )
+      return this.range
     },
     {
       key: process.env.NODE_ENV !== 'production' && 'calculateRange',
@@ -1895,45 +1895,67 @@ const findNearestBinarySearch = (
   }
 }
 
-function calculateRange({
-  measurements,
-  outerSize,
-  scrollOffset,
-  lanes,
-  flat,
-}: {
-  measurements: Array<VirtualItem>
-  outerSize: number
-  scrollOffset: number
-  lanes: number
-  flat: Float64Array | null
-}) {
+// Monomorphic Float64Array variant — reads start values directly at stride
+// 2 instead of through a getter closure. JITs the inner load to a typed-
+// array bounds-check + load with no indirect call.
+function findNearestBinarySearchFlat(
+  flat: Float64Array,
+  high: number,
+  value: number,
+) {
+  let low = 0
+  while (low <= high) {
+    const middle = ((low + high) / 2) | 0
+    const currentValue = flat[middle * 2]!
+
+    if (currentValue < value) {
+      low = middle + 1
+    } else if (currentValue > value) {
+      high = middle - 1
+    } else {
+      return middle
+    }
+  }
+  return low > 0 ? low - 1 : 0
+}
+
+function calculateRangeImpl(
+  measurements: Array<VirtualItem>,
+  outerSize: number,
+  scrollOffset: number,
+  lanes: number,
+  flat: Float64Array | null,
+) {
   const lastIndex = measurements.length - 1
-  // When the lanes===1 fast-path is active, read start/end directly from the
-  // flat Float64Array instead of going through the lazy-view Proxy. Cuts
-  // ~17 Proxy.get traps per scroll for the binary search alone.
-  const getStart = flat
-    ? (index: number) => flat[index * 2]!
-    : (index: number) => measurements[index]!.start
-  const getEnd = flat
-    ? (index: number) => flat[index * 2]! + flat[index * 2 + 1]!
-    : (index: number) => measurements[index]!.end
 
   // handle case when item count is less than or equal to lanes
   if (measurements.length <= lanes) {
-    return {
-      startIndex: 0,
-      endIndex: lastIndex,
-    }
+    return { startIndex: 0, endIndex: lastIndex }
   }
 
+  if (lanes === 1 && flat !== null) {
+    // Hot single-lane path: typed-array reads, no closures, no Proxy traps.
+    const startIndex = findNearestBinarySearchFlat(flat, lastIndex, scrollOffset)
+    let endIndex = startIndex
+    const limit = scrollOffset + outerSize
+    while (
+      endIndex < lastIndex &&
+      flat[endIndex * 2]! + flat[endIndex * 2 + 1]! < limit
+    ) {
+      endIndex++
+    }
+    return { startIndex, endIndex }
+  }
+
+  // Fallback (lanes > 1 or no flat array): closure-based reads.
+  const getStart = (index: number) => measurements[index]!.start
   let startIndex = findNearestBinarySearch(0, lastIndex, getStart, scrollOffset)
   let endIndex = startIndex
 
   if (lanes === 1) {
     while (
       endIndex < lastIndex &&
-      getEnd(endIndex) < scrollOffset + outerSize
+      measurements[endIndex]!.end < scrollOffset + outerSize
     ) {
       endIndex++
     }

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1935,7 +1935,11 @@ function calculateRangeImpl(
 
   if (lanes === 1 && flat !== null) {
     // Hot single-lane path: typed-array reads, no closures, no Proxy traps.
-    const startIndex = findNearestBinarySearchFlat(flat, lastIndex, scrollOffset)
+    const startIndex = findNearestBinarySearchFlat(
+      flat,
+      lastIndex,
+      scrollOffset,
+    )
     let endIndex = startIndex
     const limit = scrollOffset + outerSize
     while (

--- a/packages/virtual-core/tests/bench.bench.ts
+++ b/packages/virtual-core/tests/bench.bench.ts
@@ -200,6 +200,29 @@ describe('Layer 2: setOptions() — simulating React render storm', () => {
   })
 })
 
+// ─── Scroll loop: per-scroll-frame cost (calculateRange + memo machinery) ─────
+
+describe('Scroll loop: 10k scroll events on warm virtualizer', () => {
+  for (const n of [1000, 100000]) {
+    bench(`n=${n}, 10k scrolls`, () => {
+      const v = makeVirt(n)
+      v.scrollRect = { width: 800, height: 600 }
+      for (let i = 0; i < 10_000; i++) {
+        v.scrollOffset = i * 5
+        ;(v as any).calculateRange()
+      }
+    })
+    bench(`n=${n}, 10k scrolls + getVirtualItems`, () => {
+      const v = makeVirt(n)
+      v.scrollRect = { width: 800, height: 600 }
+      for (let i = 0; i < 10_000; i++) {
+        v.scrollOffset = i * 5
+        v.getVirtualItems()
+      }
+    })
+  }
+})
+
 // ─── Layer 6: defaultRangeExtractor ──────────────────────────────────────────
 
 describe('Layer 6: defaultRangeExtractor', () => {

--- a/packages/virtual-core/tests/bench.bench.ts
+++ b/packages/virtual-core/tests/bench.bench.ts
@@ -204,11 +204,15 @@ describe('Layer 2: setOptions() — simulating React render storm', () => {
 
 describe('Scroll loop: 10k scroll events on warm virtualizer', () => {
   for (const n of [1000, 100000]) {
+    // Wrap offsets at the real max scroll so every iteration exercises a
+    // representative range (not the degenerate end-of-list state once
+    // i*5 exceeds totalSize - viewport).
+    const maxOffset = n * 30 - 600
     bench(`n=${n}, 10k scrolls`, () => {
       const v = makeVirt(n)
       v.scrollRect = { width: 800, height: 600 }
       for (let i = 0; i < 10_000; i++) {
-        v.scrollOffset = i * 5
+        v.scrollOffset = (i * 5) % maxOffset
         ;(v as any).calculateRange()
       }
     })
@@ -216,7 +220,7 @@ describe('Scroll loop: 10k scroll events on warm virtualizer', () => {
       const v = makeVirt(n)
       v.scrollRect = { width: 800, height: 600 }
       for (let i = 0; i < 10_000; i++) {
-        v.scrollOffset = i * 5
+        v.scrollOffset = (i * 5) % maxOffset
         v.getVirtualItems()
       }
     })


### PR DESCRIPTION
## 🎯 Changes

Cut per-scroll-frame allocations on the default `lanes === 1` path. Range computation previously allocated an options object and two closures on every scroll event; it now does the same work allocation-free, reducing GC pressure during continuous scroll.

- `calculateRangeImpl` takes positional args instead of an options object.
- New `findNearestBinarySearchFlat(flat, high, value)` — monomorphic typed-array binary search that indexes `flat[i*2]` directly. The closure-based `findNearestBinarySearch` is kept for the `lanes > 1` / no-`flat` fallback.
- The `lanes === 1` forward-walk reads `start + size` from the typed array inline.

### Motivation

`scrollOffset` is a memo dep on `calculateRange`, so its body runs on every scroll event. On `main` each run …

- allocates a 5-field `{measurements, outerSize, scrollOffset, lanes, flat}` options object,
- allocates two `getStart` / `getEnd` closures, and
- pays a polymorphic indirect call through those closures for each binary-search probe.

The codebase already has a `Float64Array` fast path for `lanes === 1` (`_flatMeasurements`). This change reads from it directly instead of through closures.

### Performance

| Benchmark | `main` (Hz) | This PR (Hz) | Δ |
|---|--:|--:|--:|
| `n=1000, 10k scrolls` | 104.7 | 130.7 | +25% |
| `n=100000, 10k scrolls` | 87.7 | 109.1 | +24% |
| `n=1000, 10k scrolls + getVirtualItems` | 34.0 | 37.1 | +9% |
| `n=100000, 10k scrolls + getVirtualItems` | 32.5 | 35.3 | +9% |

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

This PR was assisted by Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **Bug Fixes**
  * Clears virtualized range state when there are no measurements or when the outer container size is zero.

* **Performance Improvements**
  * Reduced per-scroll allocations during continuous scrolling, with the biggest gains when running with a single lane.

* **Tests**
  * Added a new scroll-loop benchmark suite that simulates thousands of rapid scroll frames to compare range-only vs. full virtual item updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->