### PR TITLE
Scrolling fix

### DIFF
--- a/.changeset/cold-ads-lose.md
+++ b/.changeset/cold-ads-lose.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Fixed observeElementOffset to prevent continuous rerenders during or after scrolling

--- a/.changeset/cold-ads-lose.md
+++ b/.changeset/cold-ads-lose.md
@@ -2,4 +2,4 @@
 '@tanstack/virtual-core': patch
 ---
 
-Fixed observeElementOffset to prevent continuous rerenders during or after scrolling
+Skip redundant scroll events at unchanged offset

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -779,6 +779,13 @@ export class Virtualizer<
           // self-write — by the time the user has moved 1.5 px, the
           // intended value will already have been consumed by a prior
           // scroll event and cleared.
+          if (offset === this.scrollOffset && isScrolling === true) {
+            // this prevents continous rerenders
+            isScrolling = false;
+            this.isScrolling = false;
+            this.scrollOffset = offset
+            this.maybeNotify();
+          }
           if (
             this._intendedScrollOffset !== null &&
             Math.abs(offset - this._intendedScrollOffset) < 1.5
@@ -804,7 +811,6 @@ export class Virtualizer<
           if (this.scrollState) {
             this.scheduleScrollReconcile()
           }
-          this.maybeNotify()
         }),
       )
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -779,11 +779,7 @@ export class Virtualizer<
           // which forces a render that triggers another such event: an
           // infinite re-render loop. Ignore it. (Self-writes are handled by
           // the `_intendedScrollOffset` reconciliation just below.)
-          if (
-            isScrolling &&
-            this._intendedScrollOffset === null &&
-            offset === this.scrollOffset
-          ) {
+          if (isScrolling && offset === this.scrollOffset) {
             return
           }
           

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -811,6 +811,7 @@ export class Virtualizer<
           if (this.scrollState) {
             this.scheduleScrollReconcile()
           }
+          this.maybeNotify()
         }),
       )
 

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -794,13 +794,6 @@ export class Virtualizer<
           // self-write — by the time the user has moved 1.5 px, the
           // intended value will already have been consumed by a prior
           // scroll event and cleared.
-          if (offset === this.scrollOffset && isScrolling === true) {
-            // this prevents continous rerenders
-            isScrolling = false;
-            this.isScrolling = false;
-            this.scrollOffset = offset
-            this.maybeNotify();
-          }
           if (
             this._intendedScrollOffset !== null &&
             Math.abs(offset - this._intendedScrollOffset) < 1.5

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -779,7 +779,11 @@ export class Virtualizer<
           // which forces a render that triggers another such event: an
           // infinite re-render loop. Ignore it. (Self-writes are handled by
           // the `_intendedScrollOffset` reconciliation just below.)
-          if (isScrolling && offset === this.scrollOffset) {
+          if (
+            isScrolling &&
+            this._intendedScrollOffset === null &&
+            offset === this.scrollOffset
+          ) {
             return
           }
           

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -772,6 +772,21 @@ export class Virtualizer<
 
       this.unsubs.push(
         this.options.observeElementOffset(this, (offset, isScrolling) => {
+          // A scroll event that reports movement but lands on the offset we
+          // already hold — and isn't a self-write read-back — is a spurious
+          // no-op re-emit that Safari/Firefox fire after a re-render's layout
+          // (Chrome doesn't). Treating it as scrolling re-arms `isScrolling`,
+          // which forces a render that triggers another such event: an
+          // infinite re-render loop. Ignore it. (Self-writes are handled by
+          // the `_intendedScrollOffset` reconciliation just below.)
+          if (
+            isScrolling &&
+            this._intendedScrollOffset === null &&
+            offset === this.scrollOffset
+          ) {
+            return
+          }
+          
           // If this scroll event looks like the browser's read-back of a
           // value we just wrote, prefer our intended (sub-pixel-accurate)
           // value over the browser's rounded one. The 1.5 px tolerance is

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -786,7 +786,7 @@ export class Virtualizer<
           ) {
             return
           }
-          
+
           // If this scroll event looks like the browser's read-back of a
           // value we just wrote, prefer our intended (sub-pixel-accurate)
           // value over the browser's rounded one. The 1.5 px tolerance is


### PR DESCRIPTION
Added check to observeElementOffset to prevent continuous re-renders

## 🎯 Changes

Currently, `observeElementOffset` causes `isScrolling` to get stuck as true for as long as `offset > 0`. This causes continuous rerenders even after scrolling stops. The `this.maybeNotify();` call also causes continuous rerenders while scrolling. Both of these issues cause the scroll bar to flicker. This fix adds a check to make sure that scrolling only causes notifications once, when the scrolling stops.

## ✅ Checklist

- [✅] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [✅] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [✅] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a continuous re-render issue during or after scrolling in the virtualized list.
  * Improved scroll offset observation by skipping redundant intended-offset reconciliation when the reported offset already matches the current scroll position during active scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->