### PR TITLE
fix(virtual-core): sync `scrollOffset` in `applyScrollAdjustment` so end-anchored resize is not lost to browser clamp

### DIFF
--- a/.changeset/resize-adjust-scrolloffset-sync.md
+++ b/.changeset/resize-adjust-scrolloffset-sync.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Sync `scrollOffset` in `applyScrollAdjustment` so end-anchored streaming resize isn't lost to browser clamp
+
+With `anchorTo: 'end'` and a dynamically growing last item (token streaming), `resizeItem` writes the scroll adjustment to `scrollTop` before the consumer has grown the sizer, so the browser clamps the write and no scroll event fires. `scrollOffset` stayed stale, the next tick's `wasAtEnd` check failed, and the viewport drifted away from the end. This fix carries the intended target in `scrollOffset` (zeroing `scrollAdjustments`) the same way the prepend path in `setOptions` does, so the next `getVirtualDistanceFromEnd()` reads the post-adjustment position.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -692,6 +692,19 @@ export class Virtualizer<
         adjustments: (this.scrollAdjustments += delta),
         behavior,
       })
+      // Eagerly carry the intended target in `scrollOffset` so callers that
+      // read it before the next scroll event — notably the next `resizeItem`
+      // tick's `getVirtualDistanceFromEnd()` / `wasAtEnd` check — see the
+      // post-adjustment position even when the DOM `scrollTop` write was
+      // clamped because the consumer hasn't grown the sizer yet (`notify()`
+      // runs after this in `resizeItem`). Same idea as the eager
+      // `scrollOffset` adjustment for prepend in `setOptions` (#1176). The
+      // adjustment is now baked into `scrollOffset`, so zero
+      // `scrollAdjustments` to keep their sum invariant.
+      if (this.scrollOffset !== null) {
+        this.scrollOffset += this.scrollAdjustments
+        this.scrollAdjustments = 0
+      }
     }
   }
 

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -2380,6 +2380,33 @@ test('anchorTo:end keeps a pinned streaming message pinned as it grows', () => {
   expect(options.adjustments).toBe(70)
 })
 
+test('anchorTo:end stays pinned across consecutive resizes when the scrollTop write is clamped', () => {
+  const messages = Array.from({ length: 5 }, (_, i) => ({ id: `m-${i}` }))
+  const { virtualizer, scrollToFn } = createChatVirtualizer({
+    messages,
+    offset: 50,
+  })
+
+  // First growth tick. The DOM `scrollTop` write may be clamped because the
+  // consumer hasn't grown the sizer yet (`notify()` runs after the
+  // adjustment in `resizeItem`), so no scroll event fires — `scrollToFn`
+  // here is a no-op mock, mirroring that.
+  virtualizer.resizeItem(4, 120)
+  expect(scrollToFn).toHaveBeenCalledTimes(1)
+  expect(scrollToFn.mock.calls[0]![1].adjustments).toBe(70)
+  scrollToFn.mockClear()
+
+  // Second growth tick with no scroll event in between. Before the fix,
+  // `getVirtualDistanceFromEnd()` would compute against the stale
+  // `scrollOffset` (50) and a grown `getTotalSize()` (320), conclude we had
+  // drifted 70 px from the end (> `scrollEndThreshold: 1`), and skip the
+  // adjustment — drifting forever from tick 2 onward.
+  virtualizer.resizeItem(4, 200)
+  expect(scrollToFn).toHaveBeenCalledTimes(1)
+  expect(scrollToFn.mock.calls[0]![0]).toBe(120)
+  expect(scrollToFn.mock.calls[0]![1].adjustments).toBe(80)
+})
+
 test('anchorTo:end does not follow streaming growth when user is away from end', () => {
   const messages = Array.from({ length: 8 }, (_, i) => ({ id: `m-${i}` }))
   const { virtualizer, scrollToFn } = createChatVirtualizer({


### PR DESCRIPTION
## 🎯 Changes

With `anchorTo: 'end'` and a dynamically growing last item (e.g. a streaming chat reply measured via `measureElement`), the viewport drifts away from the end starting on the **second** resize tick.

`resizeItem`'s `wasAtEnd` branch runs in this order:

1. update `itemSizeCache` → `getTotalSize()` is now larger
2. `applyScrollAdjustment(newTotal − prevTotal)` → `_scrollToOffset(getScrollOffset(), {adjustments: delta})` → `el.scrollTo({top: scrollOffset + delta})`
3. `notify(false)` → consumer re-renders → sets the sizer `style.height` to the new `getTotalSize()`

Step 2 writes `scrollTop` while the container is still at the **old** total height (the consumer hasn't re-rendered yet), so the browser clamps the write back to the old max. Because `scrollTop` didn't move, no scroll event fires, `this.scrollOffset` stays stale, and the next tick's `getVirtualDistanceFromEnd()` reads `newTotal − viewport − staleOffset > scrollEndThreshold` → `wasAtEnd = false` → no further adjustments.

**Fix:** in `applyScrollAdjustment`, after `_scrollToOffset` has recorded `_intendedScrollOffset`, also bake the adjustment into `this.scrollOffset` and zero `scrollAdjustments` (so their sum stays invariant for callers like the `itemStart < getScrollOffset() + scrollAdjustments` predicate). The DOM write may still be clamped, but `scrollOffset` now carries the intended position so the next `wasAtEnd` check stays true and the adjustment lands once the consumer has grown the sizer. This is the same idea as #1176 (eager `scrollOffset` adjustment for prepend in `setOptions`), applied to the resize-adjust path.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
