### PR TITLE
fix(virtual-core): viewport drifts when above-viewport rows resize over multiple frames

### DIFF
--- a/.changeset/scroll-direction-self-write-readback.md
+++ b/.changeset/scroll-direction-self-write-readback.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Don't latch a scroll direction from the read-back of the virtualizer's own adjustment write
+
+`applyScrollAdjustment` folds the pending adjustment into `scrollOffset` eagerly, so the browser's scroll event for that write arrives at exactly the held offset. The scroll-direction computation treated that equality as `'backward'`, which made the default `shouldAdjustScrollPositionOnItemSizeChange` skip above-viewport re-measure compensation for the rest of the `isScrollingResetDelay` window — so during multi-frame reflows (e.g. a side pane's width animation re-wrapping rows while scrolled up) most frames went uncompensated and the viewport drifted. An event at the held offset carries no direction information, so the direction now stays unchanged in that case; real gestures always move the offset and still latch normally.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -816,10 +816,17 @@ export class Virtualizer<
           this._intendedScrollOffset = null
 
           this.scrollAdjustments = 0
+          // If the offset hasn't moved, this is the echo of our own
+          // adjustment write — `applyScrollAdjustment` already folded it
+          // into `scrollOffset`. There's no direction to infer, so leave
+          // it alone; a real gesture always moves the offset.
+          const prevOffset = this.getScrollOffset()
           this.scrollDirection = isScrolling
-            ? this.getScrollOffset() < offset
-              ? 'forward'
-              : 'backward'
+            ? prevOffset === offset
+              ? this.scrollDirection
+              : prevOffset < offset
+                ? 'forward'
+                : 'backward'
             : null
           this.scrollOffset = offset
           this.isScrolling = isScrolling

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -2214,6 +2214,203 @@ test('scroll-up jank: idle (scrollDirection=null) still applies adjustment', () 
   expect(scrollToFn).toHaveBeenCalled()
 })
 
+// ─── scroll direction vs. self-write read-backs ─────────────────────────────
+//
+// `applyScrollAdjustment` folds the pending adjustment into `scrollOffset`
+// eagerly, so the browser's scroll event for our own `scrollTop` write
+// arrives at exactly the offset we already hold (directly, or snapped there
+// by the `_intendedScrollOffset` sub-pixel reconciliation). That equality
+// carries no directional information — it must not be classified as a
+// `'backward'` gesture, or the default
+// `shouldAdjustScrollPositionOnItemSizeChange` skips above-viewport
+// compensation for the whole `isScrollingResetDelay` window (see the
+// multi-frame reflow test below).
+
+function createAdjustmentVirtualizer({
+  count = 30,
+  offset,
+}: {
+  count?: number
+  offset: number
+}) {
+  const scrollToFn = vi.fn()
+  let scrollCb: ((o: number, s: boolean) => void) | null = null
+  const v = new Virtualizer({
+    count,
+    estimateSize: () => 50,
+    getScrollElement: () =>
+      ({
+        scrollTop: offset,
+        scrollLeft: 0,
+        scrollHeight: count * 50,
+        clientHeight: 200,
+        offsetHeight: 200,
+      }) as any,
+    scrollToFn,
+    observeElementRect: (_inst: any, cb: any) => {
+      cb({ width: 400, height: 200 })
+      return () => {}
+    },
+    observeElementOffset: (_inst: any, cb: any) => {
+      scrollCb = cb
+      cb(offset, false)
+      return () => {}
+    },
+  })
+  v._didMount()
+  v._willUpdate()
+  v['getMeasurements']()
+  scrollToFn.mockClear()
+  return {
+    v,
+    scrollToFn,
+    emitScroll: (o: number, isScrolling: boolean) => scrollCb!(o, isScrolling),
+  }
+}
+
+test('self-write read-back of a positive adjustment does not latch a scroll direction', () => {
+  const { v, scrollToFn, emitScroll } = createAdjustmentVirtualizer({
+    offset: 600,
+  })
+
+  v['applyScrollAdjustment'](40)
+  expect(scrollToFn).toHaveBeenCalledTimes(1)
+  // The adjustment is already folded into `scrollOffset`.
+  expect(v.scrollOffset).toBe(640)
+
+  // Browser read-back of our own write: a scroll event at exactly the
+  // offset we already hold.
+  emitScroll(640, true)
+
+  // The event traversed the listener (not swallowed by a no-op guard)...
+  expect(v.isScrolling).toBe(true)
+  // ...but an echo of our own write carries no direction information.
+  expect(v.scrollDirection).toBeNull()
+})
+
+test('self-write read-back of a negative adjustment does not latch a scroll direction', () => {
+  const { v, emitScroll } = createAdjustmentVirtualizer({ offset: 600 })
+
+  v['applyScrollAdjustment'](-40)
+  expect(v.scrollOffset).toBe(560)
+
+  emitScroll(560, true)
+
+  expect(v.isScrolling).toBe(true)
+  expect(v.scrollDirection).toBeNull()
+})
+
+test('self-write read-back rounded by the browser still does not latch a direction', () => {
+  const { v, emitScroll } = createAdjustmentVirtualizer({ offset: 600 })
+
+  v['applyScrollAdjustment'](40.5)
+  expect(v.scrollOffset).toBe(640.5)
+
+  // The browser rounds the write to an integer; the `_intendedScrollOffset`
+  // reconciliation snaps the read-back to the held value.
+  emitScroll(640, true)
+
+  expect(v.isScrolling).toBe(true)
+  expect(v.scrollDirection).toBeNull()
+  expect(v.scrollOffset).toBe(640.5)
+})
+
+test('real scroll gestures still latch forward/backward and reset to null', () => {
+  const { v, emitScroll } = createAdjustmentVirtualizer({ offset: 600 })
+
+  emitScroll(650, true)
+  expect(v.scrollDirection).toBe('forward')
+  emitScroll(700, true)
+  expect(v.scrollDirection).toBe('forward')
+
+  emitScroll(620, true)
+  expect(v.scrollDirection).toBe('backward')
+  emitScroll(540, true)
+  expect(v.scrollDirection).toBe('backward')
+
+  // Debounced reset emission after the gesture ends.
+  emitScroll(540, false)
+  expect(v.scrollDirection).toBeNull()
+  expect(v.isScrolling).toBe(false)
+})
+
+test('adjustment read-back during a real backward gesture preserves the direction', () => {
+  const { v, emitScroll } = createAdjustmentVirtualizer({ offset: 600 })
+
+  // Real backward gesture: the user is scrolling up.
+  emitScroll(500, true)
+  expect(v.scrollDirection).toBe('backward')
+
+  // A compensation write lands mid-gesture; its read-back arrives at
+  // exactly the held offset. The user is still scrolling up, so the
+  // direction must survive, not be erased.
+  v['applyScrollAdjustment'](30)
+  expect(v.scrollOffset).toBe(530)
+  emitScroll(530, true)
+
+  expect(v.isScrolling).toBe(true)
+  expect(v.scrollDirection).toBe('backward')
+
+  // After the reset emission, a fresh adjustment read-back must yield
+  // null — not a stale 'backward' from before the reset.
+  emitScroll(530, false)
+  expect(v.scrollDirection).toBeNull()
+
+  v['applyScrollAdjustment'](30)
+  expect(v.scrollOffset).toBe(560)
+  emitScroll(560, true)
+  expect(v.isScrolling).toBe(true)
+  expect(v.scrollDirection).toBeNull()
+})
+
+test('multi-frame reflow: above-viewport re-measure compensation is never skipped by self-write read-backs', () => {
+  // The end-to-end shape of the bug, with the DEFAULT
+  // shouldAdjustScrollPositionOnItemSizeChange: a side pane opens and its
+  // width animation re-wraps rows for several frames while the user sits
+  // scrolled up. Each frame re-measures above-viewport rows; the browser
+  // echoes the compensation write back as a scroll event before the next
+  // frame's ResizeObserver callbacks (scroll fires before RO in the
+  // rendering steps). If that echo latches 'backward', every later frame's
+  // re-measure is skipped until the isScrollingResetDelay reset and the
+  // viewport drifts.
+  const { v, scrollToFn, emitScroll } = createAdjustmentVirtualizer({
+    offset: 600,
+  })
+
+  // Pre-measure the rows we'll re-wrap so they're in itemSizeCache — the
+  // backward-skip leg of the default predicate only applies to re-measures.
+  for (let i = 0; i < 5; i++) {
+    v.resizeItem(i, 55)
+    v['getMeasurements']()
+  }
+  // 5 first measurements × +5 each were compensated and folded.
+  expect(v.scrollOffset).toBe(625)
+  // Settle: the browser caught up and the scrolling window expired.
+  emitScroll(625, false)
+  expect(v.isScrolling).toBe(false)
+  expect(v.scrollDirection).toBeNull()
+  scrollToFn.mockClear()
+
+  // The reflow: 5 frames, each re-measures one above-viewport row +20px,
+  // then the browser delivers the scroll event for the compensation write
+  // the way it would between frames.
+  for (let i = 0; i < 5; i++) {
+    const before = v.scrollOffset!
+    v.resizeItem(i, 75)
+    v['getMeasurements']()
+    if (v.scrollOffset! !== before) {
+      // A compensation write happened — deliver its read-back.
+      emitScroll(v.scrollOffset!, true)
+    }
+  }
+
+  // Every frame's above-viewport delta must have been compensated:
+  // 625 + 5 × 20 = 725. If the first frame's read-back latched 'backward',
+  // frames 2-5 were skipped and the offset is stuck at 645.
+  expect(scrollToFn).toHaveBeenCalledTimes(5)
+  expect(v.scrollOffset).toBe(725)
+})
+
 // ─── end anchoring / chat-style reverse virtualization ──────────────────────
 
 function createChatVirtualizer({


### PR DESCRIPTION
## 🎯 Changes

Folding adjustments eagerly into `scrollOffset` means the browser's scroll event for an adjustment write now arrives at exactly the offset we already hold, and the direction computation classified that equality as `'backward'`. With `isScrolling` held for `isScrollingResetDelay` after the event, the default `shouldAdjustScrollPositionOnItemSizeChange` then skipped every above-viewport re-measure compensation until the reset — so multi-frame reflows (a side pane's width animation re-wrapping rows while the user is scrolled up) drifted the viewport, with only ~1 frame in 9 compensated.

An event at the held offset carries no directional information, so keep the previous direction for it instead of computing the comparison. Real gestures still latch normally (their read-backs never equal the held offset, which moves with each event), an equality read-back during a real backward gesture correctly stays `'backward'`, and the `isScrolling === false` reset emission still clears the direction.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

This PR was assisted by Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll direction handling so the app no longer misreads its own scroll adjustment read-backs as user scrolling.
  * Prevents viewport drift and skipped compensation during multi-frame reflows, especially after content changes above the viewport.
  * Real scroll gestures still update direction normally, and direction now stays unchanged when the offset hasn’t actually moved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->