### PR TITLE
fix(virtual-core): reset iOS gesture/deferral state on cleanup

### DIFF
--- a/.changeset/reset-ios-deferral-state-on-cleanup.md
+++ b/.changeset/reset-ios-deferral-state-on-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Reset iOS gesture/deferral state in `cleanup()` so it no longer leaks across scroll element swaps.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -741,6 +741,19 @@ export class Virtualizer<
       this.rafId = null
     }
     this.scrollState = null
+    // The iOS gesture/deferral state is scoped to the current scroll
+    // element: the touch listeners that maintain it were just removed, and
+    // an in-flight touch keeps targeting the old element (implicit touch
+    // capture), so the new element never reports it. Carrying the state
+    // over would replay a stale deferred delta on the new element's first
+    // flush, and a cleanup that lands mid-touch or inside the post-touchend
+    // grace window would strand _iosTouching / _iosJustTouchEnded as true
+    // (the listener unsub clears the grace timer, and with it the only
+    // pending reset of the flag), deferring every adjustment on the new
+    // element until its next touch cycle.
+    this._iosDeferredAdjustment = 0
+    this._iosTouching = false
+    this._iosJustTouchEnded = false
     this.scrollElement = null
     this.targetWindow = null
   }

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -1766,6 +1766,134 @@ test('iOS Phase 1: new touchstart during grace window cancels pending flush time
   })
 })
 
+// Helper for the element-swap tests below: like makeIOSVirtualizerWithRealEl
+// but getScrollElement reads a mutable holder, so tests can swap the scroll
+// element and re-run _willUpdate (which triggers cleanup + re-attach).
+function makeIOSVirtualizerWithSwappableEl(
+  scrollToFn: ReturnType<typeof vi.fn>,
+  mockWindow: any,
+  { startScrolling = false }: { startScrolling?: boolean } = {},
+) {
+  const makeEl = () =>
+    makeMockScrollElement({
+      scrollTop: 100,
+      scrollLeft: 0,
+      scrollHeight: 500,
+      clientHeight: 200,
+      offsetHeight: 200,
+      ownerDocument: { defaultView: mockWindow },
+    })
+  const holder = { el: makeEl() }
+  let scrollCallback: ((offset: number, isScrolling: boolean) => void) | null =
+    null
+  const v = new Virtualizer({
+    count: 10,
+    estimateSize: () => 50,
+    getScrollElement: () => holder.el as any,
+    scrollToFn,
+    observeElementRect: () => {},
+    observeElementOffset: (_inst, cb) => {
+      scrollCallback = cb
+      cb(100, startScrolling)
+      return () => {}
+    },
+  })
+  v._willUpdate()
+  v['getMeasurements']()
+  return {
+    v,
+    holder,
+    makeEl,
+    getScrollCallback: () => scrollCallback!,
+  }
+}
+
+test('iOS Phase 1: scroll-element swap does not replay a stale deferred adjustment', () => {
+  withFakeIOSUserAgent(() => {
+    const scrollToFn = vi.fn()
+    const mockWindow = {
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    }
+    const { v, holder, makeEl, getScrollCallback } =
+      makeIOSVirtualizerWithSwappableEl(scrollToFn, mockWindow, {
+        startScrolling: true,
+      })
+    scrollToFn.mockClear()
+
+    // A resize above the viewport during the live scroll defers its
+    // adjustment instead of writing scrollTop.
+    v.resizeItem(0, 100)
+    expect(scrollToFn).not.toHaveBeenCalled()
+    expect(v['_iosDeferredAdjustment']).toBe(50)
+
+    // The scroll element is swapped while the deferral is pending — the
+    // delta was computed against the old element's content and must not
+    // survive into the new element.
+    holder.el = makeEl()
+    v._willUpdate()
+    expect(v['_iosDeferredAdjustment']).toBe(0)
+
+    // The new element's first quiescence must not write the stale delta.
+    scrollToFn.mockClear()
+    getScrollCallback()(100, false)
+    expect(scrollToFn).not.toHaveBeenCalled()
+  })
+})
+
+test('iOS Phase 1: scroll-element swap mid-touch does not strand _iosTouching', () => {
+  withFakeIOSUserAgent(() => {
+    const mockWindow = {
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    }
+    const { v, holder, makeEl } = makeIOSVirtualizerWithSwappableEl(
+      vi.fn(),
+      mockWindow,
+    )
+    dispatchTouchEvent(holder.el, 'touchstart')
+    expect(v['_iosTouching']).toBe(true)
+
+    // The in-flight touch keeps targeting the old element (implicit touch
+    // capture), so the new element will never deliver its touchend. Without
+    // a reset, every adjustment on the new element would be deferred and
+    // the flush blocked until the user's next full touch cycle.
+    holder.el = makeEl()
+    v._willUpdate()
+    expect(v['_iosTouching']).toBe(false)
+  })
+})
+
+test('iOS Phase 1: scroll-element swap during grace window does not strand _iosJustTouchEnded', () => {
+  withFakeIOSUserAgent(() => {
+    let timerId = 0
+    const timers = new Map<number, () => void>()
+    const mockWindow = {
+      setTimeout: (fn: () => void, _ms: number) => {
+        const id = ++timerId
+        timers.set(id, fn)
+        return id
+      },
+      clearTimeout: (id: number) => timers.delete(id),
+    }
+    const { v, holder, makeEl } = makeIOSVirtualizerWithSwappableEl(
+      vi.fn(),
+      mockWindow,
+    )
+    dispatchTouchEvent(holder.el, 'touchstart')
+    dispatchTouchEvent(holder.el, 'touchend')
+    expect(v['_iosJustTouchEnded']).toBe(true)
+
+    // Swapping inside the grace window removes the listeners and clears the
+    // grace timer — which was the only pending reset of the flag. Without
+    // the cleanup reset the flag would stay true indefinitely.
+    holder.el = makeEl()
+    v._willUpdate()
+    expect(v['_iosJustTouchEnded']).toBe(false)
+    expect(timers.size).toBe(0)
+  })
+})
+
 // ─── Phase 2a: subpixel scrollTop reconciliation ─────────────────────────────
 
 test('Phase 2a: browser-rounded scrollTop after self-write is reconciled to intended value', () => {


### PR DESCRIPTION
`cleanup()` resets `scrollState`, `scrollElement`, and `targetWindow`, but not the iOS gesture/deferral state: `_iosDeferredAdjustment`, `_iosTouching`, `_iosJustTouchEnded`.

That state is scoped to the current scroll element. The touch listeners maintaining it are removed by the unsubs, and an in-flight touch keeps targeting the old element (implicit touch capture), so the new element never delivers the matching `touchend`. Carrying the state across a scroll-element swap breaks three ways:

- A deferred adjustment accumulated against the old element is applied to the new element's `scrollTop` on its first flush.
- A swap mid-touch strands `_iosTouching = true`. Every adjustment on the new element is then deferred, and `_flushIosDeferredIfReady` early-returns, until the user's next full touch cycle.
- A swap inside the post-touchend grace window strands `_iosJustTouchEnded = true` indefinitely: the listener unsub clears the grace timer, and that timer held the only pending reset of the flag.

This is easy to hit in chat UIs, where switching conversations remounts the scroller while the user is mid-flick.

Fix: reset the three fields in `cleanup()`. The grace timer needs no extra handling since the listener unsub already clears it.

Tests: three regression tests following the existing Phase 1 patterns, one per failure mode. On current `main` without the src change they fail (3 failed / 102 passed); with it, 105 pass. `pnpm vitest run`, `tsc`, and `eslint ./src` in `packages/virtual-core` are green.

Found while auditing the 3.2.0 to 3.14.5 upgrade in a Matrix client fork (mindroom-ai/mindroom-cinny#83).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where iOS touch and scroll state could persist when switching scroll elements.
  * Prevented deferred scroll adjustments from being incorrectly applied to a newly assigned element.
  * Ensured post-touch interaction state and related timers are cleared during cleanup.

* **Chores**
  * Added a patch release for the virtual-core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->