### PR TITLE
fix(virtual-core): invalidate measurements when gap option changes

### DIFF
--- a/.changeset/eighty-ants-slide.md
+++ b/.changeset/eighty-ants-slide.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-virtual': patch
+'@tanstack/virtual-core': patch
+---
+
+Made gap option changes invalidate measurements

--- a/.changeset/eighty-ants-slide.md
+++ b/.changeset/eighty-ants-slide.md
@@ -1,5 +1,4 @@
 ---
-'@tanstack/react-virtual': patch
 '@tanstack/virtual-core': patch
 ---
 

--- a/packages/react-virtual/tests/index.test.tsx
+++ b/packages/react-virtual/tests/index.test.tsx
@@ -27,6 +27,7 @@ interface ListProps {
   itemSize?: number
   rangeExtractor?: (range: Range) => number[]
   dynamic?: boolean
+  gap?: number
 }
 
 function List({
@@ -37,6 +38,7 @@ function List({
   itemSize,
   rangeExtractor,
   dynamic,
+  gap,
 }: ListProps) {
   renderer()
 
@@ -57,6 +59,7 @@ function List({
     },
     measureElement: () => itemSize ?? 0,
     rangeExtractor,
+    gap,
   })
 
   React.useEffect(() => {
@@ -158,6 +161,23 @@ test('should handle count change', () => {
   expect(screen.queryByText('Row 2')).toBeInTheDocument()
   expect(screen.queryByText('Row 4')).toBeInTheDocument()
   expect(screen.queryByText('Row 5')).not.toBeInTheDocument()
+})
+
+test('should handle gap change', () => {
+  const { rerender } = render(<List count={10} gap={0} />)
+
+  expect(screen.getByTestId('item-1')).toHaveStyle({
+    transform: 'translateY(50px)',
+  })
+
+  rerender(<List count={10} gap={40} />)
+
+  expect(screen.getByTestId('item-1')).toHaveStyle({
+    transform: 'translateY(90px)',
+  })
+  expect(screen.getByTestId('item-2')).toHaveStyle({
+    transform: 'translateY(180px)',
+  })
 })
 
 test('should handle handle height change', () => {

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1132,6 +1132,7 @@ export class Virtualizer<
       this.options.enabled,
       this.options.lanes,
       this.options.laneAssignmentMode,
+      this.options.gap,
     ],
     (
       count,
@@ -1141,6 +1142,7 @@ export class Virtualizer<
       enabled,
       lanes,
       laneAssignmentMode,
+      gap,
     ) => {
       const lanesChanged =
         this.prevLanes !== undefined && this.prevLanes !== lanes
@@ -1161,6 +1163,7 @@ export class Virtualizer<
         enabled,
         lanes,
         laneAssignmentMode,
+        gap,
       }
     },
     {
@@ -1179,6 +1182,7 @@ export class Virtualizer<
         enabled,
         lanes,
         laneAssignmentMode,
+        gap,
       },
       _itemSizeCacheVersion,
     ) => {
@@ -1237,7 +1241,6 @@ export class Virtualizer<
       // At n=100k this drops cold-mount cost from ~2.5ms (eager object
       // allocation) to roughly the cost of a single typed-array fill.
       if (lanes === 1) {
-        const gap = this.options.gap
         // Reuse flat backing if large enough; else grow (preserving data
         // before `min` to mirror the slice-and-rebuild contract).
         const need = count * 2
@@ -1308,7 +1311,7 @@ export class Virtualizer<
           const prevInLane =
             prevIndex !== undefined ? measurements[prevIndex] : undefined
           start = prevInLane
-            ? prevInLane.end + this.options.gap
+            ? prevInLane.end + gap
             : paddingStart + scrollMargin
         } else {
           // No cache - use original logic (find shortest lane)
@@ -1318,7 +1321,7 @@ export class Virtualizer<
               : this.getFurthestMeasurement(measurements, i)
 
           start = furthestMeasurement
-            ? furthestMeasurement.end + this.options.gap
+            ? furthestMeasurement.end + gap
             : paddingStart + scrollMargin
 
           lane = furthestMeasurement

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -1271,6 +1271,50 @@ test('lazy fast path: respects paddingStart + scrollMargin + gap', () => {
   expect(m[1]!.size).toBe(40)
 })
 
+test('changing gap invalidates cached measurements', () => {
+  const baseOptions = {
+    count: 5,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  }
+  const v = new Virtualizer({ ...baseOptions, gap: 0 })
+  let m = v['getMeasurements']()
+  expect(m[1]!.start).toBe(50)
+  expect(v.getTotalSize()).toBe(250)
+
+  v.setOptions({ ...baseOptions, gap: 40 })
+  m = v['getMeasurements']()
+  // start(i) = i * (size + gap); previously stale starts survived a gap-only
+  // change because gap was missing from the measurement memo dependencies
+  expect(m[1]!.start).toBe(90)
+  expect(m[2]!.start).toBe(180)
+  expect(v.getTotalSize()).toBe(410)
+})
+
+test('changing gap invalidates cached measurements (multi-lane)', () => {
+  const baseOptions = {
+    count: 4,
+    lanes: 2,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  }
+  const v = new Virtualizer({ ...baseOptions, gap: 0 })
+  let m = v['getMeasurements']()
+  expect(m[2]!.start).toBe(50)
+
+  v.setOptions({ ...baseOptions, gap: 40 })
+  m = v['getMeasurements']()
+  // second row in each lane starts at prevInLane.end + gap
+  expect(m[2]!.start).toBe(90)
+  expect(m[3]!.start).toBe(90)
+})
+
 test('lazy fast path: VirtualItem fields are correct', () => {
   const v = new Virtualizer({
     count: 3,


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

resolves #1222

`gap` was missing from the `getMeasurementOptions` memo dependencies, so a gap-only option change never invalidated cached measurements. 

The list kept the layout computed with the old `gap` until something else (count change, item resize, remount) recomputed it.

## Changes

- Add `options.gap` to the measurement memo key and thread it through to `getMeasurements`, replacing the direct `this.options.gap` reads
- Regression tests: virtual-core (single-lane and multi-lane) and react-virtual (gap change via rerender)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/recognized an optional spacing **gap** prop for virtualized lists, so item/row positioning reflects updated gap values.
* **Bug Fixes**
  * Virtualized measurements now correctly refresh when **gap** changes, preventing stale cached positions.
  * Total size and lane/row start calculations stay accurate after gap updates.
* **Tests**
  * Added regression coverage for both single-lane and multi-lane **gap** changes.
* **Chores**
  * Added a patch release note calling out that **gap** changes invalidate measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->