### PR TITLE
perf(virtual-core): replace multi-lane backward scan with incremental laneEnds argmin

### DIFF
--- a/.changeset/blue-icons-appear.md
+++ b/.changeset/blue-icons-appear.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Improve multi-lane virtualization performance: replace the backward scan in getMeasurements with an incremental per-lane argmin (O(lanes) shortest-lane lookup). Placement output is unchanged and the single-lane fast path is untouched.

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1082,47 +1082,6 @@ export class Virtualizer<
     return this.scrollOffset
   }
 
-  private getFurthestMeasurement = (
-    measurements: Array<VirtualItem>,
-    index: number,
-  ) => {
-    const furthestMeasurementsFound = new Map<number, true>()
-    const furthestMeasurements = new Map<number, VirtualItem>()
-    for (let m = index - 1; m >= 0; m--) {
-      const measurement = measurements[m]!
-
-      if (furthestMeasurementsFound.has(measurement.lane)) {
-        continue
-      }
-
-      const previousFurthestMeasurement = furthestMeasurements.get(
-        measurement.lane,
-      )
-      if (
-        previousFurthestMeasurement == null ||
-        measurement.end > previousFurthestMeasurement.end
-      ) {
-        furthestMeasurements.set(measurement.lane, measurement)
-      } else if (measurement.end < previousFurthestMeasurement.end) {
-        furthestMeasurementsFound.set(measurement.lane, true)
-      }
-
-      if (furthestMeasurementsFound.size === this.options.lanes) {
-        break
-      }
-    }
-
-    return furthestMeasurements.size === this.options.lanes
-      ? Array.from(furthestMeasurements.values()).sort((a, b) => {
-          if (a.end === b.end) {
-            return a.index - b.index
-          }
-
-          return a.end - b.end
-        })[0]
-      : undefined
-  }
-
   private getMeasurementOptions = memo(
     () => [
       this.options.count,
@@ -1281,12 +1240,21 @@ export class Virtualizer<
       const laneLastIndex: Array<number | undefined> = new Array(lanes).fill(
         undefined,
       )
+      // Running end position of each lane's last item, so the shortest lane
+      // can be found with an O(lanes) argmin instead of the old backward walk
+      // through `measurements` (getFurthestMeasurement). `filledLanes` tracks
+      // how many lanes have at least one item, mirroring the previous
+      // "all lanes seen → shortest lane, else i % lanes" branch.
+      const laneEnds = new Float64Array(lanes)
+      let filledLanes = 0
 
       // Initialize from existing measurements (before min)
       for (let m = 0; m < min; m++) {
         const item = measurements[m]
         if (item) {
+          if (laneLastIndex[item.lane] === undefined) filledLanes++
           laneLastIndex[item.lane] = m
+          laneEnds[item.lane] = item.end
         }
       }
 
@@ -1310,22 +1278,35 @@ export class Virtualizer<
           start = prevInLane
             ? prevInLane.end + this.options.gap
             : paddingStart + scrollMargin
+        } else if (filledLanes === lanes) {
+          // No cache, every lane seeded: place in the shortest lane.
+          // Read the running per-lane ends (O(lanes) argmin) instead of the
+          // old backward scan. Tie-break on the lane's last-item index to
+          // preserve the previous sort-by-(end, index) placement exactly.
+          let bestLane = 0
+          let bestEnd = laneEnds[0]!
+          let bestIdx = laneLastIndex[0]!
+          for (let l = 1; l < lanes; l++) {
+            const e = laneEnds[l]!
+            if (e < bestEnd || (e === bestEnd && laneLastIndex[l]! < bestIdx)) {
+              bestLane = l
+              bestEnd = e
+              bestIdx = laneLastIndex[l]!
+            }
+          }
+          lane = bestLane
+          start = bestEnd + this.options.gap
+
+          if (shouldCacheLane) {
+            this.laneAssignments.set(i, lane)
+          }
         } else {
-          // No cache - use original logic (find shortest lane)
-          const furthestMeasurement =
-            this.options.lanes === 1
-              ? measurements[i - 1]
-              : this.getFurthestMeasurement(measurements, i)
+          // No cache and not every lane seeded yet — seed lanes in order,
+          // matching the previous `i % lanes` fallback for the first row.
+          lane = i % this.options.lanes
+          start = paddingStart + scrollMargin
 
-          start = furthestMeasurement
-            ? furthestMeasurement.end + this.options.gap
-            : paddingStart + scrollMargin
-
-          lane = furthestMeasurement
-            ? furthestMeasurement.lane
-            : i % this.options.lanes
-
-          if (this.options.lanes > 1 && shouldCacheLane) {
+          if (shouldCacheLane) {
             this.laneAssignments.set(i, lane)
           }
         }
@@ -1347,8 +1328,10 @@ export class Virtualizer<
           lane,
         }
 
-        // ✅ Performance: Update lane's last item index
+        // ✅ Performance: Update lane's last item index + running end
+        if (laneLastIndex[lane] === undefined) filledLanes++
         laneLastIndex[lane] = i
+        laneEnds[lane] = end
       }
 
       this.measurementsCache = measurements

--- a/packages/virtual-core/tests/bench.bench.ts
+++ b/packages/virtual-core/tests/bench.bench.ts
@@ -243,3 +243,51 @@ describe('Layer 6: defaultRangeExtractor', () => {
     })
   }
 })
+
+// ─── Multi-lane: cold-mount lane assignment (getFurthestMeasurement) ──────────
+// Divergent lane heights (variable estimateSize) force the backward scan in
+// getFurthestMeasurement to walk further before all lanes "settle".
+
+describe('Multi-lane cold mount: getMeasurements with variable sizes', () => {
+  for (const lanes of [2, 4, 8]) {
+    for (const n of [10000, 100000]) {
+      bench(`lanes=${lanes} n=${n}`, () => {
+        const v = new Virtualizer({
+          count: n,
+          lanes,
+          // Variable sizes → lanes diverge → longer backward scans.
+          estimateSize: (i: number) => 20 + ((i * 37) % 120),
+          getScrollElement: () => null,
+          scrollToFn: () => {},
+          observeElementRect: () => {},
+          observeElementOffset: () => {},
+        })
+        ;(v as any).getMeasurements()
+      })
+    }
+  }
+})
+
+// Worst case: 'measure' mode keeps items uncached across rebuilds, so every
+// rebuild re-runs getFurthestMeasurement for the whole (unmeasured) list.
+describe('Multi-lane rebuild storm: measure mode, 50× getMeasurements', () => {
+  for (const lanes of [2, 4]) {
+    const n = 20000
+    bench(`lanes=${lanes} n=${n} ×50 rebuilds`, () => {
+      const v = new Virtualizer({
+        count: n,
+        lanes,
+        laneAssignmentMode: 'measured',
+        estimateSize: (i: number) => 20 + ((i * 37) % 120),
+        getScrollElement: () => null,
+        scrollToFn: () => {},
+        observeElementRect: () => {},
+        observeElementOffset: () => {},
+      })
+      for (let r = 0; r < 50; r++) {
+        ;(v as any).itemSizeCacheVersion++
+        ;(v as any).getMeasurements()
+      }
+    })
+  }
+})

--- a/packages/virtual-core/tests/bench.bench.ts
+++ b/packages/virtual-core/tests/bench.bench.ts
@@ -268,6 +268,29 @@ describe('Multi-lane cold mount: getMeasurements with variable sizes', () => {
   }
 })
 
+// Uniform sizes: the common same-height grid. The old backward scan settled
+// quickly here (balanced lanes → shallow walk), so this isolates the flat
+// constant-factor win from dropping the per-placement Map allocations + sort,
+// independent of scan depth. Guards against regressing the most common case.
+describe('Multi-lane cold mount: getMeasurements with uniform sizes', () => {
+  for (const lanes of [2, 4, 8]) {
+    for (const n of [10000, 100000]) {
+      bench(`lanes=${lanes} n=${n}`, () => {
+        const v = new Virtualizer({
+          count: n,
+          lanes,
+          estimateSize: () => 50,
+          getScrollElement: () => null,
+          scrollToFn: () => {},
+          observeElementRect: () => {},
+          observeElementOffset: () => {},
+        })
+        ;(v as any).getMeasurements()
+      })
+    }
+  }
+})
+
 // Worst case: 'measure' mode keeps items uncached across rebuilds, so every
 // rebuild re-runs getFurthestMeasurement for the whole (unmeasured) list.
 describe('Multi-lane rebuild storm: measure mode, 50× getMeasurements', () => {

--- a/packages/virtual-core/tests/lane-equivalence.test.ts
+++ b/packages/virtual-core/tests/lane-equivalence.test.ts
@@ -1,0 +1,301 @@
+// Differential ("oracle") test for the multi-lane lane-assignment optimization.
+//
+// The old code placed an uncached item by scanning `measurements` backward for
+// the shortest lane's furthest item; that scan is now an O(lanes) argmin over a
+// running `laneEnds` array. The reference below is a verbatim port of the *old*
+// algorithm (not a reuse of the real source — that would be tautological), and
+// each test compares the real Virtualizer against it. Verify the port by
+// diffing against its origin at commit 850947a4:
+//   getFurthestMeasurement (backward scan): src/index.ts#L1085
+//   getMeasurements placement loop:         src/index.ts#L1278
+//   https://github.com/TanStack/virtual/blob/850947a42dc322ac1dd0328a15ed344763932b60/packages/virtual-core/src/index.ts
+
+import { describe, expect, it, vi } from 'vitest'
+import { Virtualizer } from '../src/index'
+
+type RefItem = {
+  index: number
+  start: number
+  size: number
+  end: number
+  lane: number
+}
+
+// Removed Virtualizer.getFurthestMeasurement, ported verbatim: the shortest
+// lane's furthest item (tie-break end, then index), or undefined until every
+// lane has been seen.
+function getFurthestMeasurement(
+  measurements: Array<RefItem>,
+  index: number,
+  lanes: number,
+) {
+  const found = new Map<number, true>()
+  const furthest = new Map<number, RefItem>()
+  for (let m = index - 1; m >= 0; m--) {
+    const meas = measurements[m]!
+    if (found.has(meas.lane)) continue
+    const prev = furthest.get(meas.lane)
+    if (prev == null || meas.end > prev.end) {
+      furthest.set(meas.lane, meas)
+    } else if (meas.end < prev.end) {
+      found.set(meas.lane, true)
+    }
+    if (found.size === lanes) break
+  }
+  return furthest.size === lanes
+    ? Array.from(furthest.values()).sort((a, b) =>
+        a.end === b.end ? a.index - b.index : a.end - b.end,
+      )[0]
+    : undefined
+}
+
+// Deterministic LCG so failures reproduce.
+function makeRng(seed: number) {
+  let s = seed >>> 0
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+// Verbatim port of the old getMeasurements placement loop (lanes > 1). Without
+// resizeItem() it is a plain fresh build (argmin path); with resizeItem() it
+// also covers incremental rebuilds (min > 0, prefix seeding) and cached/uncached
+// mixing. Caches key by index, matching the real Virtualizer's default key.
+class ReferenceVirtualizer {
+  private measurements: Array<RefItem> = []
+  private itemSizeCache = new Map<number, number>()
+  private laneAssignments = new Map<number, number>()
+  private pendingMin: number | null = null
+
+  constructor(
+    private opts: {
+      count: number
+      lanes: number
+      gap: number
+      paddingStart: number
+      scrollMargin: number
+      laneAssignmentMode: 'estimate' | 'measured'
+      estimateSize: (i: number) => number
+    },
+  ) {}
+
+  // Mirrors Virtualizer.resizeItem: on a real delta, dirty pendingMin and
+  // record the measured size.
+  resizeItem(index: number, size: number) {
+    const item = this.measurements[index]
+    if (!item) return
+    const itemSize = this.itemSizeCache.get(index) ?? item.size
+    if (size === itemSize) return
+    if (this.pendingMin === null || index < this.pendingMin) {
+      this.pendingMin = index
+    }
+    this.itemSizeCache.set(index, size)
+  }
+
+  build() {
+    const {
+      count,
+      lanes,
+      gap,
+      paddingStart,
+      scrollMargin,
+      laneAssignmentMode,
+      estimateSize,
+    } = this.opts
+    const min = this.pendingMin ?? 0
+    this.pendingMin = null
+    const measurements = this.measurements.slice(0, min)
+
+    // Seed per-lane last-item index from the retained prefix (before min).
+    const laneLastIndex: Array<number | undefined> = new Array(lanes).fill(
+      undefined,
+    )
+    for (let m = 0; m < min; m++) {
+      const item = measurements[m]
+      if (item) laneLastIndex[item.lane] = m
+    }
+
+    for (let i = min; i < count; i++) {
+      const cachedLane = this.laneAssignments.get(i)
+      let lane: number
+      let start: number
+
+      const shouldCacheLane =
+        laneAssignmentMode === 'estimate' || this.itemSizeCache.has(i)
+
+      if (cachedLane !== undefined && lanes > 1) {
+        // Cached lane: O(1) continue from the lane's previous item.
+        lane = cachedLane
+        const prevIndex = laneLastIndex[lane]
+        const prevInLane =
+          prevIndex !== undefined ? measurements[prevIndex] : undefined
+        start = prevInLane ? prevInLane.end + gap : paddingStart + scrollMargin
+      } else {
+        // No cache: find the shortest lane via the backward scan.
+        const furthest =
+          lanes === 1
+            ? measurements[i - 1]
+            : getFurthestMeasurement(measurements, i, lanes)
+        start = furthest ? furthest.end + gap : paddingStart + scrollMargin
+        lane = furthest ? furthest.lane : i % lanes
+        if (lanes > 1 && shouldCacheLane) {
+          this.laneAssignments.set(i, lane)
+        }
+      }
+
+      const measuredSize = this.itemSizeCache.get(i)
+      const size =
+        typeof measuredSize === 'number' ? measuredSize : estimateSize(i)
+      const end = start + size
+      measurements[i] = { index: i, start, size, end, lane }
+      laneLastIndex[lane] = i
+    }
+
+    this.measurements = measurements
+    return measurements
+  }
+}
+
+describe('multi-lane placement equivalence with the original backward scan', () => {
+  const laneCounts = [2, 3, 4, 5, 8]
+
+  for (const lanes of laneCounts) {
+    it(`matches reference for lanes=${lanes} across random size distributions`, () => {
+      for (let seed = 1; seed <= 20; seed++) {
+        const rng = makeRng(seed * 7919 + lanes)
+        const count = 200 + Math.floor(rng() * 800)
+        const gap = Math.floor(rng() * 12) // 0..11
+        const paddingStart = Math.floor(rng() * 40)
+        const scrollMargin = Math.floor(rng() * 40)
+        // Varied sizes so lanes diverge and tie-breaks actually get exercised;
+        // occasional equal sizes to force `end` ties.
+        const sizes = Array.from({ length: count }, () =>
+          rng() < 0.25 ? 30 : 10 + Math.floor(rng() * 100),
+        )
+        const sizeOf = (i: number) => sizes[i]!
+
+        // Fresh build (no resizeItem): drives the shortest-lane argmin at
+        // min = 0. The cached-lane branch stays dormant here (a cache written
+        // this build is only read on a later one) — covered by the suite below.
+        const expected = new ReferenceVirtualizer({
+          count,
+          lanes,
+          gap,
+          paddingStart,
+          scrollMargin,
+          laneAssignmentMode: 'estimate',
+          estimateSize: sizeOf,
+        }).build()
+
+        const v = new Virtualizer({
+          count,
+          lanes,
+          gap,
+          paddingStart,
+          scrollMargin,
+          estimateSize: sizeOf,
+          getScrollElement: () => null,
+          scrollToFn: vi.fn(),
+          observeElementRect: vi.fn(),
+          observeElementOffset: vi.fn(),
+        })
+        const actual = (v as any).getMeasurements() as Array<any>
+
+        expect(actual.length).toBe(expected.length)
+        for (let i = 0; i < count; i++) {
+          const a = actual[i]
+          const e = expected[i]!
+          // Compare the geometry-defining fields explicitly for a precise diff.
+          expect({
+            index: a.index,
+            lane: a.lane,
+            start: a.start,
+            size: a.size,
+            end: a.end,
+          }).toEqual({
+            index: e.index,
+            lane: e.lane,
+            start: e.start,
+            size: e.size,
+            end: e.end,
+          })
+        }
+      }
+    })
+  }
+})
+
+// `measured` mode with interleaved resizeItem() calls, covering the paths the
+// fresh-build suite can't: incremental rebuilds with min > 0 (prefix seeding the
+// argmin reads from) and the cached-lane branch mixing with uncached items.
+describe('multi-lane placement equivalence under measured-mode rebuilds', () => {
+  const laneCounts = [2, 3, 4, 5]
+
+  for (const lanes of laneCounts) {
+    it(`matches reference across resize-driven rebuilds for lanes=${lanes}`, () => {
+      for (let seed = 1; seed <= 12; seed++) {
+        const rng = makeRng(seed * 104729 + lanes)
+        const count = 120 + Math.floor(rng() * 380)
+        const gap = Math.floor(rng() * 10)
+        const paddingStart = Math.floor(rng() * 30)
+        const scrollMargin = Math.floor(rng() * 30)
+        const estimateSize = (i: number) => 20 + ((i * 37) % 90)
+
+        const reference = new ReferenceVirtualizer({
+          count,
+          lanes,
+          gap,
+          paddingStart,
+          scrollMargin,
+          laneAssignmentMode: 'measured',
+          estimateSize,
+        })
+
+        const v = new Virtualizer({
+          count,
+          lanes,
+          gap,
+          paddingStart,
+          scrollMargin,
+          laneAssignmentMode: 'measured',
+          estimateSize,
+          getScrollElement: () => null,
+          scrollToFn: vi.fn(),
+          observeElementRect: vi.fn(),
+          observeElementOffset: vi.fn(),
+        })
+
+        const assertEquivalent = (label: string) => {
+          const expected = reference.build()
+          const actual = (v as any).getMeasurements() as Array<any>
+          expect(actual.length, `${label}: length`).toBe(expected.length)
+          for (let i = 0; i < count; i++) {
+            const a = actual[i]
+            const e = expected[i]!
+            expect(
+              { lane: a.lane, start: a.start, size: a.size, end: a.end },
+              `${label}: item ${i}`,
+            ).toEqual({ lane: e.lane, start: e.start, size: e.size, end: e.end })
+          }
+        }
+
+        // Initial estimate-only build (nothing measured yet).
+        assertEquivalent('initial')
+
+        // Measure a random subset, then rebuild — the min(i) dirties pendingMin
+        // so rebuilds start from min > 0 and reuse the cached prefix.
+        for (let round = 0; round < 4; round++) {
+          const measures = 5 + Math.floor(rng() * 15)
+          for (let k = 0; k < measures; k++) {
+            const index = Math.floor(rng() * count)
+            const size = 15 + Math.floor(rng() * 140)
+            reference.resizeItem(index, size)
+            ;(v as any).resizeItem(index, size)
+          }
+          assertEquivalent(`round ${round}`)
+        }
+      }
+    })
+  }
+})

--- a/packages/virtual-core/tests/lane-equivalence.test.ts
+++ b/packages/virtual-core/tests/lane-equivalence.test.ts
@@ -224,6 +224,51 @@ describe('multi-lane placement equivalence with the original backward scan', () 
       }
     })
   }
+
+  // Uniform sizes make every lane's ends equal at each row, so every
+  // shortest-lane pick is an `end` tie resolved purely by the last-item-index
+  // tie-break — the common same-height-grid case, and the hardest exercise of
+  // that tie-break. Split out because the randomized suite above rarely yields
+  // all-equal rows.
+  it('matches reference for uniform sizes (every placement is an end-tie)', () => {
+    for (const lanes of [2, 3, 4, 5, 8]) {
+      for (const gap of [0, 4, 10]) {
+        const count = 500
+        const sizeOf = () => 42
+
+        const expected = new ReferenceVirtualizer({
+          count,
+          lanes,
+          gap,
+          paddingStart: 0,
+          scrollMargin: 0,
+          laneAssignmentMode: 'estimate',
+          estimateSize: sizeOf,
+        }).build()
+
+        const v = new Virtualizer({
+          count,
+          lanes,
+          gap,
+          estimateSize: sizeOf,
+          getScrollElement: () => null,
+          scrollToFn: vi.fn(),
+          observeElementRect: vi.fn(),
+          observeElementOffset: vi.fn(),
+        })
+        const actual = (v as any).getMeasurements() as Array<any>
+
+        for (let i = 0; i < count; i++) {
+          const a = actual[i]
+          const e = expected[i]!
+          expect(
+            { lane: a.lane, start: a.start, size: a.size, end: a.end },
+            `lanes=${lanes} gap=${gap} item ${i}`,
+          ).toEqual({ lane: e.lane, start: e.start, size: e.size, end: e.end })
+        }
+      }
+    }
+  })
 })
 
 // `measured` mode with interleaved resizeItem() calls, covering the paths the

--- a/packages/virtual-core/tests/lane-equivalence.test.ts
+++ b/packages/virtual-core/tests/lane-equivalence.test.ts
@@ -321,7 +321,12 @@ describe('multi-lane placement equivalence under measured-mode rebuilds', () => 
             expect(
               { lane: a.lane, start: a.start, size: a.size, end: a.end },
               `${label}: item ${i}`,
-            ).toEqual({ lane: e.lane, start: e.start, size: e.size, end: e.end })
+            ).toEqual({
+              lane: e.lane,
+              start: e.start,
+              size: e.size,
+              end: e.end,
+            })
           }
         }
 


### PR DESCRIPTION
## 🎯 Changes

Multi-lane (`lanes > 1`) placement in `getMeasurements` found the shortest lane by scanning `measurements` backward through already-placed items (`getFurthestMeasurement`) on every uncached placement. This PR keeps a running `laneEnds` array, updated in the build loop, and picks the shortest lane with an `O(lanes)` argmin instead — so per-placement work no longer grows with scan depth. `getMeasurements` is ~3–11× faster on multi-lane cold mount and rebuilds.

- `getMeasurements` keeps a `laneEnds: Float64Array(lanes)` and a `filledLanes` counter, updated as each item is placed.
- The uncached branch picks the shortest lane via `argmin(laneEnds)`, keeping the tie-break (`end`, then last-item index) exact so placement is unchanged.
- `getFurthestMeasurement` is removed; the `lanes === 1` fast path is untouched.

> Sibling of #1206, which dropped closures from `calculateRange` on the `lanes === 1` hot path. This one targets the `lanes > 1` placement path.

### Correctness

Placement is byte-for-byte identical to the old algorithm for the supported `gap >= 0` range. `tests/lane-equivalence.test.ts` ports the original backward-scan verbatim as an oracle and asserts identical `lane` / `start` / `size` / `end` for every item — across fresh `estimate`-mode builds (lanes ∈ {2,3,4,5,8} × 20 seeds) and `measured`-mode rebuilds driven by random `resizeItem()` (covering incremental `min > 0` rebuilds and the cached-lane path).

> [!NOTE]
> Negative `gap`: the old scan tracked each lane's *max-end* item, while `laneEnds` tracks its *last* item — these coincide for any `gap >= 0`. A negative `gap` that overlaps items can shift the pick, but that's not a regression: the cached-lane path already used the last item, so the old code was already inconsistent there. This PR makes both paths consistent; `gap >= 0` is unaffected.

### Performance

Added multi-lane cases to `tests/bench.bench.ts` (cold-mount `getMeasurements` with variable and uniform sizes, and a `measured`-mode rebuild storm). Mean ms, lower is better:

| scenario | before | after | speedup |
| --- | ---: | ---: | ---: |
| cold mount · variable · lanes=2 · n=100k | 25.86 | 7.52 | 3.4× |
| cold mount · variable · lanes=4 · n=100k | 43.57 | 8.39 | 5.2× |
| cold mount · variable · lanes=8 · n=100k | 80.23 | 8.93 | 9.0× |
| cold mount · uniform · lanes=2 · n=100k | 24.07 | 6.37 | 3.8× |
| cold mount · uniform · lanes=4 · n=100k | 29.83 | 6.67 | 4.5× |
| cold mount · uniform · lanes=8 · n=100k | 52.81 | 8.09 | 6.5× |
| rebuild storm · lanes=2 · ×50 | 180.64 | 27.28 | 6.6× |
| rebuild storm · lanes=4 · ×50 | 320.51 | 41.81 | 7.7× |

Two independent wins: 
1. dropping the per-placement `Map` allocations + sort is a flat constant-factor gain that applies to every case (hence uniform sizes — the common same-height grid — improve too, ~4–6×)
2. removing the backward scan adds a further gain that grows with lane count when heights diverge. Single-lane (`lanes === 1`, the default) is a separate fast path, unchanged within noise.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance of multi-lane virtualization by speeding up lane selection while preserving existing placement geometry and results, including deterministic handling of edge-case ties.
* **Tests**
  * Added new multi-lane differential/oracle coverage to confirm measurement and lane assignment equivalence across fresh builds and incremental rebuilds.
  * Expanded benchmarks for multi-lane scenarios, including cold mounts with uniform/variable lane sizes and rebuild-storm behavior in measurement mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->