### PR TITLE
fix(virtual-core): reject 0-size resizeItem when cached measurement exists

### DIFF
--- a/.changeset/zero-size-reject-measurement.md
+++ b/.changeset/zero-size-reject-measurement.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/virtual-core': patch
+---
+
+Fix: reject 0-size ResizeObserver measurement when item has cached size
+
+Prevent 0-size measurements from overwriting a previously cached size in resizeItem, avoiding infinite re-render loops when elements are temporarily hidden (e.g., display:none causes ResizeObserver to deliver 0 size, which triggers calculateRangeImpl to include all items and freeze the browser).

--- a/packages/virtual-core/src/index.ts
+++ b/packages/virtual-core/src/index.ts
@@ -1515,6 +1515,12 @@ export class Virtualizer<
     }
 
     const itemSize = this.itemSizeCache.get(key) ?? cachedSize
+
+    // Prevent 0-size measurements from overwriting a previously cached size.
+    // This avoids infinite re-renders when elements are temporarily hidden
+    // (e.g., display:none), causing ResizeObserver to deliver 0 size.
+    if (size === 0 && this.itemSizeCache.has(key)) return
+
     const delta = size - itemSize
 
     if (delta !== 0) {

--- a/packages/virtual-core/tests/index.test.ts
+++ b/packages/virtual-core/tests/index.test.ts
@@ -711,6 +711,75 @@ test('resizeItem on unknown index is a no-op', () => {
   expect(virtualizer['itemSizeCache'].size).toBe(0)
 })
 
+
+test('resizeItem should reject 0-size when previous measured size exists', () => {
+  const virtualizer = new Virtualizer({
+    count: 5,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  })
+
+  virtualizer['getMeasurements']()
+
+  // Seed a measurement with a real non-zero size
+  virtualizer.resizeItem(2, 130)
+  expect(virtualizer['getMeasurements']()[2]!.size).toBe(130)
+
+  // Attempt to overwrite with 0 (simulating display:none RO callback)
+  // Should be rejected since we have a previous measurement
+  virtualizer.resizeItem(2, 0)
+  expect(virtualizer['getMeasurements']()[2]!.size).toBe(130)
+
+  // A subsequent resize to a new non-zero value should still work
+  virtualizer.resizeItem(2, 80)
+  expect(virtualizer['getMeasurements']()[2]!.size).toBe(80)
+})
+
+test('resizeItem should accept first-time 0-size measurement', () => {
+  const virtualizer = new Virtualizer({
+    count: 1,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  })
+
+  virtualizer['getMeasurements']()
+
+  // First-time measurement of a genuinely 0-height item should be accepted
+  virtualizer.resizeItem(0, 0)
+  expect(virtualizer['getMeasurements']()[0]!.size).toBe(0)
+})
+
+test('resizeItem: 0-size followed by non-zero update should still work', () => {
+  const virtualizer = new Virtualizer({
+    count: 3,
+    estimateSize: () => 50,
+    getScrollElement: () => null,
+    scrollToFn: vi.fn(),
+    observeElementRect: vi.fn(),
+    observeElementOffset: vi.fn(),
+  })
+
+  virtualizer['getMeasurements']()
+
+  // First measurement: 0 (accepted, no prior cache)
+  virtualizer.resizeItem(1, 0)
+  expect(virtualizer['getMeasurements']()[1]!.size).toBe(0)
+
+  // Later the item gets content and grows to 200 — should work
+  virtualizer.resizeItem(1, 200)
+  expect(virtualizer['getMeasurements']()[1]!.size).toBe(200)
+
+  // Now that we have a non-zero cache, a 0 should be rejected
+  virtualizer.resizeItem(1, 0)
+  expect(virtualizer['getMeasurements']()[1]!.size).toBe(200)
+})
+
 test('resizeItem out-of-order should produce correct positions regardless of measurement order', () => {
   const N = 10
   const virtualizer = new Virtualizer({


### PR DESCRIPTION
## Description

When an element is temporarily hidden (e.g., `display:none` on the container), the ResizeObserver fires with size 0. This overwrites the valid cached measurement in `resizeItem`, causing `calculateRangeImpl` to include all items in the visible range (since all items now have `end === 0`), which results in a browser freeze or `Maximum update depth exceeded` error.

## Fix

Guard `resizeItem` against accepting a 0-size measurement when the item already has a previously cached size. First-time measurements of genuinely 0-height items remain accepted (no prior cache entry).

## Tests

- Verify 0-size is rejected when previous non-zero measurement exists in cache
- Verify first-time 0-size measurement is accepted (no prior cache)
- Verify 0-size → non-zero → 0-size cycle: non-zero measured after first 0 accepted, then 0 rejected after non-zero cached

Fixes #1188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented temporary zero-size measurements from overwriting previously cached item sizes.
  * Reduced unnecessary re-renders and avoided infinite render loops when virtualized elements are temporarily hidden.
  * Improved range calculations when items briefly report zero dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->