### PR TITLE
docs(virtual-core): clarify shouldAdjustScrollPositionOnItemSizeChange usage

### DIFF
--- a/docs/api/virtualizer.md
+++ b/docs/api/virtualizer.md
@@ -572,6 +572,18 @@ shouldAdjustScrollPositionOnItemSizeChange: undefined | ((item: VirtualItem, del
 
 Provides fine-grained control over the scroll-position adjustment that fires when an above-viewport item's measured size differs from its estimated size. By default the virtualizer applies this correction only when the user is **not** scrolling backward, which avoids the well-known "items jump while scrolling up" jank. Supply this callback only if you want to override that default — for example, to apply corrections during backward scroll, or to skip them in additional scenarios.
 
+This is a virtualizer instance property, not a `VirtualizerOptions` option. Assign it directly on the virtualizer instance after creating the virtualizer:
+
+```tsx
+virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (
+  item,
+  delta,
+  instance,
+) => {
+  return item.start < instance.getScrollOffset() + instance.scrollAdjustments
+}
+```
+
 The callback receives the resized `item`, the size `delta`, and the `instance`; return `true` to apply the scroll adjustment, `false` to skip it.
 
 On iOS WebKit, scroll-position writes are deferred regardless of this callback while a finger is on screen, during momentum-scroll, and during elastic-overscroll bounce. The cumulative delta is flushed in a single write once the scroll settles, preserving iOS's native momentum physics.

--- a/packages/virtual-core/CHANGELOG.md
+++ b/packages/virtual-core/CHANGELOG.md
@@ -107,8 +107,9 @@
   Forward-scroll and idle (mount-time) adjustments still fire as before
   to preserve visual stability of the visible window. Consumers who want
   the old behavior — adjusting on every above-viewport resize regardless
-  of direction — can supply `shouldAdjustScrollPositionOnItemSizeChange`
-  which is checked before the default branch.
+  of direction — can assign `shouldAdjustScrollPositionOnItemSizeChange`
+  directly on the virtualizer instance. This instance property is checked
+  before the default branch.
 
 - Add `takeSnapshot()` instance method for scroll-restoration round-trips. ([#1168](https://github.com/TanStack/virtual/pull/1168))
   Returns the currently-measured items as plain `VirtualItem` objects;


### PR DESCRIPTION
Clarifies that `shouldAdjustScrollPositionOnItemSizeChange` is a Virtualizer instance property, not a `VirtualizerOptions` option.

The existing docs already list it under Virtualizer Instance, but the prose and changelog wording could still be read as passing the predicate through options. This updates both places to show the intended imperative assignment form.

References #1227 and follows up on the maintainer feedback in #1232.

Validation:
- `./node_modules/.bin/prettier --check docs/api/virtualizer.md packages/virtual-core/CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `shouldAdjustScrollPositionOnItemSizeChange` is configured directly on the virtualizer instance.
  * Added an example demonstrating how to assign the callback after creating a virtualizer.
  * Updated the changelog to accurately describe the instance-level override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->