### PR TITLE
fix(marko-virtual): keep the e2e app's build out of nx's target graph

### DIFF
--- a/packages/marko-virtual/e2e/app/README.md
+++ b/packages/marko-virtual/e2e/app/README.md
@@ -53,6 +53,13 @@ Install is covered by the repo-level `pnpm install` via the workspace glob
 `packages/marko-virtual/e2e/*`. A first browser run may need
 `npx playwright install chromium`.
 
+The `dev`/`build`/`preview` scripts exist for Playwright's webServer command and
+for local debugging only — `includedScripts` in package.json keeps them out of
+nx's target graph. Exposing `build` to nx makes CI run `marko-run build` as a
+parallel peer of `test:e2e`, whose webServer runs its own `marko-run build` in
+the same directory; the two race in `dist/` and one dies with
+`ENOENT ... dist/index.mjs` mid-write. Playwright owns this app's build.
+
 To debug a spec interactively, start `npm run dev -- --port 4199` (HMR) or
 `npm run preview` in one terminal and rerun `npm run test:e2e` — it reuses an
 already-running server unless CI is set. MARKO_E2E_PORT points a run at another

--- a/packages/marko-virtual/e2e/app/package.json
+++ b/packages/marko-virtual/e2e/app/package.json
@@ -14,6 +14,10 @@
     "marko": "^6.2.2"
   },
   "nx": {
+    "includedScripts": [
+      "test:e2e",
+      "test:types"
+    ],
     "implicitDependencies": [
       "@tanstack/marko-virtual"
     ],


### PR DESCRIPTION
## 🎯 Changes

Keep the e2e app's build out of nx's target graph

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that development, build, and preview scripts are intended for local debugging.
  * Documented that Playwright manages the end-to-end app build to prevent conflicting build processes.

* **Chores**
  * Updated workspace configuration to include end-to-end test and type-check scripts in Nx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->