### PR TITLE
feat(lit-virtual): re-export the virtual-core public API

### DIFF
--- a/.changeset/rich-poems-tickle.md
+++ b/.changeset/rich-poems-tickle.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/lit-virtual': minor
+---
+
+Re-export `@tanstack/virtual-core` from `@tanstack/lit-virtual`, so the core API (`Virtualizer`, `defaultRangeExtractor`, `measureElement`, the scroll observers and the shared types) can be imported from the adapter without adding `@tanstack/virtual-core` as a second dependency. Every other framework adapter already does this.

--- a/packages/lit-virtual/src/index.ts
+++ b/packages/lit-virtual/src/index.ts
@@ -10,6 +10,8 @@ import {
 import type { ReactiveController, ReactiveControllerHost } from 'lit'
 import type { PartialKeys, VirtualizerOptions } from '@tanstack/virtual-core'
 
+export * from '@tanstack/virtual-core'
+
 class VirtualizerControllerBase<
   TScrollElement extends Element | Window,
   TItemElement extends Element,

--- a/packages/lit-virtual/tests/re-exports.test.ts
+++ b/packages/lit-virtual/tests/re-exports.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+import {
+  Virtualizer,
+  defaultKeyExtractor,
+  defaultRangeExtractor,
+  elementScroll,
+  measureElement,
+  observeElementOffset,
+  observeElementRect,
+  observeWindowOffset,
+  observeWindowRect,
+  windowScroll,
+} from '../src'
+
+// `@tanstack/lit-virtual` re-exports `@tanstack/virtual-core` so consumers can
+// reach the core API without adding a second dependency, matching every other
+// framework adapter in this repo.
+
+test('re-exports the Virtualizer class from virtual-core', () => {
+  expect(typeof Virtualizer).toBe('function')
+})
+
+test('re-exports the element observers and scroller from virtual-core', () => {
+  expect(typeof observeElementRect).toBe('function')
+  expect(typeof observeElementOffset).toBe('function')
+  expect(typeof elementScroll).toBe('function')
+})
+
+test('re-exports the window observers and scroller from virtual-core', () => {
+  expect(typeof observeWindowRect).toBe('function')
+  expect(typeof observeWindowOffset).toBe('function')
+  expect(typeof windowScroll).toBe('function')
+})
+
+test('re-exports the default extractors and measureElement from virtual-core', () => {
+  expect(typeof defaultRangeExtractor).toBe('function')
+  expect(typeof defaultKeyExtractor).toBe('function')
+  expect(typeof measureElement).toBe('function')
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #839.

### Problem

`lit-virtual` is the only framework adapter that does not re-export the core package. Every other one carries the identical `export *` line:

| adapter | line |
| --- | --- |
| react-virtual | `src/index.tsx:14` |
| vue-virtual | `src/index.ts:21` |
| solid-virtual | `src/index.tsx:21` |
| svelte-virtual | `src/index.ts:14` |
| angular-virtual | `src/index.ts:27` |
| marko-virtual | `src/index.ts:56` |
| **lit-virtual** | **absent** |

So a Lit consumer who needs `defaultRangeExtractor`, `measureElement`, `Virtualizer` or any of the shared types has to install the core package as a second direct dependency, while the same code in any other adapter needs only the adapter. `docs/api/virtualizer.md` documents `defaultRangeExtractor` as exported without mentioning a second install.

This is the same gap that was closed for Vue in #588 (`allow access to virtual-core parts`), with the same one-line diff.

### Fix

One line in `packages/lit-virtual/src/index.ts` — the same core re-export the other six adapters carry, placed exactly where react-virtual puts it: after the imports, before the first declaration. The full line is in the diff.

The core package is already a direct `dependencies` entry of `lit-virtual` (`workspace:*`), so this adds nothing to the install graph. `sideEffects: false` is unchanged, so the new names stay tree-shakeable.

No name collision: core has 15 runtime exports, `lit-virtual` owns `VirtualizerController` and `WindowVirtualizerController`, and the two sets are disjoint — the built bundle goes from 2 exports to 17, the same 17 react-virtual ships.

### Release impact

Typed as a **minor**, not a patch: the change grows the package's public export surface from 2 names to 17. That matches this repo's own pattern — every `minor` changeset here comes from additive API work (react-virtual 3.14.0 shipped `### Minor Changes` for three new option names), and every `fix` ships `patch`. Happy to retitle to `fix` + `patch` and treat it purely as an adapter-parity bug instead, if you'd rather — it's a one-word change to the changeset.

## Test verification (RED → GREEN)

New file `packages/lit-virtual/tests/re-exports.test.ts` (4 tests), mirroring the `describe('re-exports')` block marko-virtual already has.

**RED — unmodified `main` (e9874f03).** Pristine `git worktree --detach` at `origin/main` with *only* the new test file copied in, core `dist/` prebuilt. The production line is absent there (`grep -c` returns `0`):

```
 ❯ tests/re-exports.test.ts (4 tests | 4 failed)
   × re-exports the Virtualizer class from virtual-core
   × re-exports the element observers and scroller from virtual-core
   × re-exports the window observers and scroller from virtual-core
   × re-exports the default extractors and measureElement from virtual-core

AssertionError: expected 'undefined' to be 'function' // Object.is equality
Expected: "function"
Received: "undefined"
 ❯ tests/re-exports.test.ts:20:30

 Test Files  1 failed | 1 passed (2)
      Tests  4 failed | 2 passed (6)
```

The 2 pre-existing Lit tests pass in that same run, so the failure is the missing exports and not a broken environment.

**GREEN — this branch:**

```
 Test Files  2 passed (2)
      Tests  6 passed (6)
```

**Built artifact**, since the export surface is the thing being changed and source alone would not prove it. After `vite build`: `dist/esm/index.js` line 2 is the emitted `export *` re-export, `dist/cjs/index.cjs` line 56 re-exports through `Object.keys(virtualCore).forEach(...)`, and `dist/esm/index.d.ts` line 3 carries the type re-export.

Importing the built package through its own `exports` map then resolves every core symbol, in ESM and in CJS, with the adapter's own classes intact:

```
core   Virtualizer              function      core   observeElementRect       function
core   defaultRangeExtractor    function      core   observeElementOffset     function
core   defaultKeyExtractor      function      core   observeWindowRect        function
core   measureElement           function      core   observeWindowOffset      function
core   elementScroll            function      lit    VirtualizerController    function
core   windowScroll             function      lit    WindowVirtualizerController function
```

## Full local suite

`nx run-many --skip-nx-cache --targets=test:sherif,test:knip,test:docs,test:eslint,test:lib,test:types,test:build,build`, run on the upstream baseline and again on this branch (`--skip-nx-cache` because 118/119 tasks were otherwise served from cache):

| | `main` e9874f03 | this branch |
| --- | --- | --- |
| test files | 9 | 10 |
| tests | 209 passed | 213 passed |
| failures | 0 | 0 |
| targets | all green, 69 projects | all green, 69 projects |

The only delta is lit-virtual going 1 file / 2 tests → 2 files / 6 tests. `knip`, `sherif`, `publint --strict`, `tsc` and `eslint` are all green with the wildcard re-export in place.

`nx affected --base=origin/main` — the literal `test:pr` job for this diff — selects `root` (sherif/knip/docs), `lit-virtual` (eslint/types/lib/build/test:build), the core `build`, and both Lit example builds. All green.

Not run locally: `test:e2e` (only react-virtual and angular-virtual define that target, and this diff reaches neither), plus the `provenance` and `version-preview` jobs, which inspect the registry and the PR rather than the tree.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Lit virtualizer package now exposes the core virtualizer API, including virtualizer utilities, observers, scrollers, range extraction, measurement, and shared types.
  - Consumers can access these capabilities directly through the Lit package.

- **Tests**
  - Added coverage verifying availability of the re-exported core API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->