### PR TITLE
fix(react-virtual): size direct DOM container before scroll adjustments

### DIFF
--- a/.changeset/fresh-chats-scroll.md
+++ b/.changeset/fresh-chats-scroll.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-virtual': patch
+---
+
+Update the direct DOM size container before applying scroll adjustments, so resizing an earlier item keeps an end-anchored list pinned even when the last item does not resize.

--- a/packages/react-virtual/e2e/app/chat-resize/index.html
+++ b/packages/react-virtual/e2e/app/chat-resize/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/react-virtual/e2e/app/chat-resize/main.tsx
+++ b/packages/react-virtual/e2e/app/chat-resize/main.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+const VIEWPORT_HEIGHT = 300
+const initialMessages = Array.from({ length: 8 }, (_, index) => ({
+  id: `m-${index}`,
+  height: index === 7 ? VIEWPORT_HEIGHT : 50,
+}))
+
+function App() {
+  const [messages, setMessages] = React.useState(initialMessages)
+  const parentRef = React.useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: messages.length,
+    getScrollElement: () => parentRef.current,
+    getItemKey: (index) => messages[index]!.id,
+    estimateSize: (index) => initialMessages[index]!.height,
+    anchorTo: 'end',
+    followOnAppend: true,
+    scrollEndThreshold: 4,
+    overscan: 4,
+    directDomUpdates: true,
+    useFlushSync: false,
+  })
+
+  React.useLayoutEffect(() => {
+    virtualizer.scrollToEnd()
+  }, [virtualizer])
+
+  return (
+    <div>
+      <button
+        id="grow-previous"
+        onClick={() => {
+          setMessages((current) =>
+            current.map((message, index) =>
+              index === current.length - 2
+                ? { ...message, height: message.height + 24 }
+                : message,
+            ),
+          )
+        }}
+      >
+        Grow previous
+      </button>
+      <div
+        ref={parentRef}
+        id="scroll-container"
+        style={{
+          height: VIEWPORT_HEIGHT,
+          width: 420,
+          overflow: 'auto',
+          overflowAnchor: 'none',
+        }}
+      >
+        <div
+          ref={virtualizer.containerRef}
+          style={{ position: 'relative', width: '100%' }}
+        >
+          {virtualizer.getVirtualItems().map((item) => (
+            <div
+              key={item.key}
+              ref={virtualizer.measureElement}
+              data-index={item.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+              }}
+            >
+              <div style={{ height: messages[item.index]!.height }}>
+                Message {messages[item.index]!.id}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/packages/react-virtual/e2e/app/chat/main.tsx
+++ b/packages/react-virtual/e2e/app/chat/main.tsx
@@ -34,8 +34,6 @@ function App() {
     followOnAppend: true,
     scrollEndThreshold: 4,
     overscan: 4,
-    directDomUpdates: true,
-    useFlushSync: false,
   })
 
   React.useLayoutEffect(() => {
@@ -85,20 +83,6 @@ function App() {
       >
         Grow last
       </button>
-      <button
-        id="grow-previous"
-        onClick={() => {
-          setMessages((current) =>
-            current.map((message, index) =>
-              index === current.length - 2
-                ? { ...message, height: message.height + 24 }
-                : message,
-            ),
-          )
-        }}
-      >
-        Grow previous
-      </button>
       <button id="scroll-to-end" onClick={() => virtualizer.scrollToEnd()}>
         End
       </button>
@@ -109,14 +93,13 @@ function App() {
         style={{
           height: 300,
           overflow: 'auto',
-          overflowAnchor: 'none',
           width: 420,
           border: '1px solid #ddd',
         }}
       >
         <div
-          ref={virtualizer.containerRef}
           style={{
+            height: virtualizer.getTotalSize(),
             position: 'relative',
             width: '100%',
           }}
@@ -135,6 +118,7 @@ function App() {
                   position: 'absolute',
                   top: 0,
                   left: 0,
+                  transform: `translateY(${item.start}px)`,
                   width: '100%',
                 }}
               >

--- a/packages/react-virtual/e2e/app/chat/main.tsx
+++ b/packages/react-virtual/e2e/app/chat/main.tsx
@@ -34,6 +34,8 @@ function App() {
     followOnAppend: true,
     scrollEndThreshold: 4,
     overscan: 4,
+    directDomUpdates: true,
+    useFlushSync: false,
   })
 
   React.useLayoutEffect(() => {
@@ -83,6 +85,20 @@ function App() {
       >
         Grow last
       </button>
+      <button
+        id="grow-previous"
+        onClick={() => {
+          setMessages((current) =>
+            current.map((message, index) =>
+              index === current.length - 2
+                ? { ...message, height: message.height + 24 }
+                : message,
+            ),
+          )
+        }}
+      >
+        Grow previous
+      </button>
       <button id="scroll-to-end" onClick={() => virtualizer.scrollToEnd()}>
         End
       </button>
@@ -93,13 +109,14 @@ function App() {
         style={{
           height: 300,
           overflow: 'auto',
+          overflowAnchor: 'none',
           width: 420,
           border: '1px solid #ddd',
         }}
       >
         <div
+          ref={virtualizer.containerRef}
           style={{
-            height: virtualizer.getTotalSize(),
             position: 'relative',
             width: '100%',
           }}
@@ -118,7 +135,6 @@ function App() {
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  transform: `translateY(${item.start}px)`,
                   width: '100%',
                 }}
               >

--- a/packages/react-virtual/e2e/app/test/chat.spec.ts
+++ b/packages/react-virtual/e2e/app/test/chat.spec.ts
@@ -162,7 +162,7 @@ test('chat mode keeps streaming bottom message pinned as it grows', async ({
 test('direct DOM chat stays pinned when a previous message grows', async ({
   page,
 }) => {
-  await page.goto('/chat/')
+  await page.goto('/chat-resize/')
   await waitForEnd(page)
   const before = await getScrollState(page)
 

--- a/packages/react-virtual/e2e/app/test/chat.spec.ts
+++ b/packages/react-virtual/e2e/app/test/chat.spec.ts
@@ -158,3 +158,20 @@ test('chat mode keeps streaming bottom message pinned as it grows', async ({
 
   await expect(page.locator('[data-testid="message-m-29"]')).toBeVisible()
 })
+
+test('direct DOM chat stays pinned when a previous message grows', async ({
+  page,
+}) => {
+  await page.goto('/chat/')
+  await waitForEnd(page)
+  const before = await getScrollState(page)
+
+  // The last message keeps its size, so its overflow cannot grow the scroll
+  // range before ResizeObserver reports the previous message's new height.
+  await page.click('#grow-previous')
+  await expect
+    .poll(async () => (await getScrollState(page)).scrollHeight)
+    .toBe(before.scrollHeight + 24)
+  await waitForEnd(page)
+  expect((await getScrollState(page)).scrollTop).toBe(before.scrollTop + 24)
+})

--- a/packages/react-virtual/e2e/app/vite.config.ts
+++ b/packages/react-virtual/e2e/app/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
         scroll: path.resolve(__dirname, 'scroll/index.html'),
         'scroll-anchor': path.resolve(__dirname, 'scroll-anchor/index.html'),
         chat: path.resolve(__dirname, 'chat/index.html'),
+        'chat-resize': path.resolve(__dirname, 'chat-resize/index.html'),
         'measure-element': path.resolve(
           __dirname,
           'measure-element/index.html',

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -160,6 +160,13 @@ function useVirtualizerBase<
 
   const resolvedOptions: VirtualizerOptions<TScrollElement, TItemElement> = {
     ...options,
+    scrollToFn: (offset, scrollOptions, instance) => {
+      // resizeItem adjusts the offset before onChange updates the DOM. Grow
+      // the sizer first so the browser cannot clamp the adjustment to its old
+      // scroll range when an earlier item grows but the last item stays fixed.
+      applyContainerSize(instance)
+      options.scrollToFn(offset, scrollOptions, instance)
+    },
     onChange: (instance, sync) => {
       const state = directRef.current
       let shouldRerender = true

--- a/packages/react-virtual/src/index.tsx
+++ b/packages/react-virtual/src/index.tsx
@@ -161,9 +161,8 @@ function useVirtualizerBase<
   const resolvedOptions: VirtualizerOptions<TScrollElement, TItemElement> = {
     ...options,
     scrollToFn: (offset, scrollOptions, instance) => {
-      // resizeItem adjusts the offset before onChange updates the DOM. Grow
-      // the sizer first so the browser cannot clamp the adjustment to its old
-      // scroll range when an earlier item grows but the last item stays fixed.
+      // resizeItem scrolls before onChange; update the sizer first so the
+      // browser does not clamp the adjustment to the old scroll range.
       applyContainerSize(instance)
       options.scrollToFn(offset, scrollOptions, instance)
     },


### PR DESCRIPTION
## 🎯 Changes

Fixes #1266.

[Live reproduction](https://tigerbea.github.io/tanstack-virtual-resize-repro/) · [Standalone source](https://github.com/tigerBeA/tanstack-virtual-resize-repro)

With `anchorTo: 'end'` and `directDomUpdates`, growing an earlier message can leave the viewport above the bottom when the last message keeps its size. `resizeItem` applies its scroll adjustment before notifying the React adapter, so the browser clamps the write against the old sizer height. The internal offset advances, but the actual DOM position remains behind. In the regression, growing the previous message by 24px leaves a persistent 24px gap.

Apply the adapter's existing, size-guarded `applyContainerSize` before delegating to `scrollToFn`. The browser then sees the updated scroll range when applying the adjustment. This covers the resize path in direct DOM mode using the same ordering principle as #1237; related to #1209. The change is scoped to the React adapter's direct DOM mode.

A separate, statically configured chat-resize E2E fixture uses `directDomUpdates` with `useFlushSync: false`; the original chat fixture and its default-mode coverage are preserved. The regression grows the previous message while keeping the last message at a fixed viewport height, then checks the real `scrollHeight` and `scrollTop`. It uses the native ResizeObserver and browser scrolling, with native scroll anchoring disabled so it cannot mask a missing virtualizer adjustment.

Validation (Node 24.8.0 from `.nvmrc`, pnpm 11.9.0 from `packageManager`):

- With only the SDK fix removed, the final `/chat-resize/` regression fails with an actual bottom gap of 24px. Restoring the fix makes it pass.
- `NX_NO_CLOUD=true NX_DAEMON=false CI=1 pnpm run test:pr --parallel=2 --skip-nx-cache` passes, including all 34 React browser tests, 7 React library tests, type checks, lint, builds, and package validation. Nx caching was disabled for this run.
- Prettier checks pass for all changed files.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a patch changeset for `@tanstack/react-virtual`.
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed end-anchored virtualized lists so they remain pinned to the bottom when an earlier item increases in height.
  - Updated scroll adjustments to use the latest container size, preventing the browser from limiting the intended scroll position.
  - Improved chat-style scrolling so users remain at the latest message after earlier content expands.

- **Tests**
  - Added end-to-end coverage for chat-style lists where a previous message grows while scrolled to the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
