### PR TITLE
fix(angular-virtual): remove deprecated effect option

### DIFF
--- a/examples/angular/dynamic/src/app/column-virtualizer-dynamic.component.ts
+++ b/examples/angular/dynamic/src/app/column-virtualizer-dynamic.component.ts
@@ -56,12 +56,10 @@ export class ColumnVirtualizerDynamic {
 
   count = this.sentences.length
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.virtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.virtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   virtualizer = injectVirtualizer(() => ({

--- a/examples/angular/dynamic/src/app/grid-virtualizer-dynamic.component.ts
+++ b/examples/angular/dynamic/src/app/grid-virtualizer-dynamic.component.ts
@@ -115,11 +115,9 @@ export class GridVirtualizerDynamic {
 
   virtualRows = viewChildren<ElementRef<HTMLDivElement>>('virtualRow')
 
-  #measureItems = effect(
-    () =>
-      this.virtualRows().forEach((el) => {
-        this.rowVirtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualRows().forEach((el) => {
+      this.rowVirtualizer.measureElement(el.nativeElement)
+    }),
   )
 }

--- a/examples/angular/dynamic/src/app/row-virtualizer-dynamic-window.component.ts
+++ b/examples/angular/dynamic/src/app/row-virtualizer-dynamic-window.component.ts
@@ -75,12 +75,10 @@ export class RowVirtualizerDynamicWindow {
 
   count = this.sentences.length
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.virtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.virtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   virtualizer = injectWindowVirtualizer(() => ({

--- a/examples/angular/dynamic/src/app/row-virtualizer-dynamic.component.ts
+++ b/examples/angular/dynamic/src/app/row-virtualizer-dynamic.component.ts
@@ -78,12 +78,10 @@ export class RowVirtualizerDynamic {
 
   count = this.sentences.length
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.virtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.virtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   virtualizer = injectVirtualizer(() => ({

--- a/examples/angular/infinite-scroll/src/app/app.component.ts
+++ b/examples/angular/infinite-scroll/src/app/app.component.ts
@@ -103,25 +103,22 @@ export class InfiniteScrollComponent {
     overscan: 5,
   }))
 
-  #fetchNextPage = effect(
-    () => {
-      const lastItem =
-        this.virtualizer.getVirtualItems()[
-          this.virtualizer.getVirtualItems().length - 1
-        ]
-      if (!lastItem) {
-        return
-      }
-      if (
-        lastItem.index >= this.allRows().length - 1 &&
-        this.query.hasNextPage() &&
-        !this.query.isFetchingNextPage()
-      ) {
-        this.query.fetchNextPage()
-      }
-    },
-    { allowSignalWrites: true },
-  )
+  #fetchNextPage = effect(() => {
+    const lastItem =
+      this.virtualizer.getVirtualItems()[
+        this.virtualizer.getVirtualItems().length - 1
+      ]
+    if (!lastItem) {
+      return
+    }
+    if (
+      lastItem.index >= this.allRows().length - 1 &&
+      this.query.hasNextPage() &&
+      !this.query.isFetchingNextPage()
+    ) {
+      this.query.fetchNextPage()
+    }
+  })
 }
 
 @Component({

--- a/examples/angular/padding/src/app/column-virtualizer-padding.component.ts
+++ b/examples/angular/padding/src/app/column-virtualizer-padding.component.ts
@@ -51,12 +51,10 @@ export class ColumnVirtualizerPadding {
 
   virtualItems = viewChildren<ElementRef<HTMLDivElement>>('virtualItem')
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.virtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.virtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   virtualizer = injectVirtualizer(() => ({

--- a/examples/angular/padding/src/app/grid-virtualizer-padding.component.ts
+++ b/examples/angular/padding/src/app/grid-virtualizer-padding.component.ts
@@ -107,13 +107,11 @@ export class GridVirtualizerPadding {
 
   virtualItems = viewChildren<ElementRef<HTMLDivElement>>('virtualItem')
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.rowVirtualizer.measureElement(el.nativeElement)
-        this.columnVirtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.rowVirtualizer.measureElement(el.nativeElement)
+      this.columnVirtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   show = signal(true)

--- a/examples/angular/padding/src/app/row-virtualizer-padding.component.ts
+++ b/examples/angular/padding/src/app/row-virtualizer-padding.component.ts
@@ -51,12 +51,10 @@ export class RowVirtualizerPadding {
 
   virtualItems = viewChildren<ElementRef<HTMLDivElement>>('virtualItem')
 
-  #measureItems = effect(
-    () =>
-      this.virtualItems().forEach((el) => {
-        this.virtualizer.measureElement(el.nativeElement)
-      }),
-    { allowSignalWrites: true },
+  #measureItems = effect(() =>
+    this.virtualItems().forEach((el) => {
+      this.virtualizer.measureElement(el.nativeElement)
+    }),
   )
 
   virtualizer = injectVirtualizer(() => ({

--- a/packages/angular-virtual/e2e/app/test/no-deprecated-effect-options.spec.ts
+++ b/packages/angular-virtual/e2e/app/test/no-deprecated-effect-options.spec.ts
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { expect, test } from '@playwright/test'
+import { glob } from 'tinyglobby'
+
+const ANGULAR_EXAMPLE_SOURCE_GLOB = 'examples/angular/*/src/**/*.ts'
+const DEPRECATED_EFFECT_OPTION = 'allowSignalWrites'
+const DEPRECATED_EFFECT_OPTION_PATTERN = new RegExp(
+  `\\b${DEPRECATED_EFFECT_OPTION}\\s*:\\s*true\\b`,
+)
+const REPO_ROOT_RELATIVE_PATH = '../../../../..'
+const SOURCE_FILE_ENCODING = 'utf-8'
+
+test('Angular examples do not pass deprecated effect options', async () => {
+  const repoRoot = resolve(import.meta.dirname, REPO_ROOT_RELATIVE_PATH)
+  const files = await glob(ANGULAR_EXAMPLE_SOURCE_GLOB, { cwd: repoRoot })
+
+  const matches: Array<string> = []
+
+  for (const file of files) {
+    const source = await readFile(resolve(repoRoot, file), SOURCE_FILE_ENCODING)
+    if (DEPRECATED_EFFECT_OPTION_PATTERN.test(source)) {
+      matches.push(file)
+    }
+  }
+
+  expect(matches, `${DEPRECATED_EFFECT_OPTION} is deprecated`).toEqual([])
+})


### PR DESCRIPTION
## Changes

Fixes #1058.

### Problem

Angular 20 logs a deprecation warning when the affected examples load because they still pass `allowSignalWrites: true` to `effect`.

### Fix

- Removed the deprecated effect option from the Angular padding, dynamic, and infinite-scroll examples.
- Added an Angular e2e guard that fails if source examples reintroduce `allowSignalWrites: true`.

## Test verification (RED -> GREEN)

RED:

- Browser verification against the Angular infinite-scroll example logged the deprecated `allowSignalWrites` warning before the fix.
- The new guard was run with the example edits reverted and failed, listing all eight affected Angular source files.

GREEN:

- Browser verification against the same example no longer logged the deprecated warning after the fix.
- The new guard passes with the fix applied.

## Full local suite proof

- Baseline upstream `main`: `pnpm run test:ci` passed.
- Final patched tree: `pnpm exec nx run-many --parallel=1 --targets=test:sherif,test:knip,test:docs,test:eslint,test:lib,test:e2e,test:types,test:build,build` passed.

The final full local suite used Nx parallelism of 1 to avoid local browser-resource flakes seen during the high-concurrency attempt. The command covers the same target matrix as `pnpm run test:ci`.

## Release impact

- [ ] Published package code changed
- [x] Examples or tests only

No changeset is included because this only updates examples and test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated Angular examples to use default effect options while preserving existing measurement and data-fetching behavior.
  - Simplified effect declarations for improved readability.

- **Tests**
  - Added end-to-end coverage that detects deprecated effect options in Angular example files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->