### PR TITLE
docs: remove duplicate page headings

### DIFF
--- a/docs/framework/marko/marko-virtual.md
+++ b/docs/framework/marko/marko-virtual.md
@@ -2,8 +2,6 @@
 title: Marko Virtual
 ---
 
-# Marko Virtual
-
 `@tanstack/marko-virtual` is the Marko 6 adapter for TanStack Virtual. It provides
 row, column, and grid virtualisation via two auto-discovered Marko tags:
 


### PR DESCRIPTION
## 🎯 Changes

Remove redundant Markdown H1s so documentation pages use the title rendered from frontmatter.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the top-level “Marko Virtual” heading from the Marko Virtual documentation.
  - All remaining adapter guidance, examples, and usage details are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->