### PR TITLE
test(marko-virtual): mark chat "Latest" e2e as fixme pending #1267

### DIFF
--- a/packages/marko-virtual/e2e/app/e2e/chat.spec.ts
+++ b/packages/marko-virtual/e2e/app/e2e/chat.spec.ts
@@ -197,7 +197,12 @@ test('scrolling near the top auto-loads older history', async ({ page }) => {
     .toBeGreaterThan(heightBefore)
 })
 
-test('Latest returns to the bottom and status flips back to At latest', async ({
+// FIXME(#1267): same prepend race as the chat-pretext sibling (#1268), flaky on CI.
+// Latest is clicked while the near-top auto history load is in flight; the prepend
+// resolves after the jump and the adapter's anchor write is clamped against the
+// not-yet-grown sizer, so the status stays "Reading history". Re-enable once #1267
+// is fixed.
+test.fixme('Latest returns to the bottom and status flips back to At latest', async ({
   page,
 }) => {
   await page.goto('/chat')


### PR DESCRIPTION
The plain chat spec's "Latest returns to the bottom and status flips back to At latest" hits the same prepend race that #1268 disabled in the chat-pretext spec, and it is failing CI on unrelated PRs (#1248, #1272). Latest is clicked while the near-top auto history load is in flight; the prepend resolves after the jump and the adapter's anchor write is clamped against the not-yet-grown sizer, so the status stays "Reading history".

## 🎯 Changes

- Mark the chat spec's "Latest" e2e as `test.fixme` with a FIXME pointing at #1267, mirroring #1268.

Re-enable once #1267 is fixed (#1273).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/virtual/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Temporarily skipped an intermittently failing chat navigation test in continuous integration.
  - Added tracking context for a race condition affecting the “Latest” status while older messages are loading.

- **User Impact**
  - No user-facing functionality or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->